### PR TITLE
chore: automated issue sync workflows

### DIFF
--- a/.github/workflows/docs-issue-sync.yml
+++ b/.github/workflows/docs-issue-sync.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/issue-close-sync.yml
+++ b/.github/workflows/issue-close-sync.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Remove stale blocker references
         uses: anthropics/claude-code-action@v1

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -26,6 +26,12 @@
 - **Action needed:** Run `docker pull ghcr.io/openclaw/openclaw:latest` on a fresh host without `docker login`. If it fails, document the PAT setup step.
 - **Fallback:** Use `1panel/openclaw` or `alpine/openclaw` from Docker Hub as a public mirror (both are community-maintained mirrors that sync from GHCR). Verify image integrity before demo.
 
+### R9: docs-issue-sync LLM Write-Access — MEDIUM
+- **Risk:** The `docs-issue-sync` workflow grants Claude Code Action write-access to **all** open issue bodies on every `docs/**` push. If the LLM misidentifies a contradiction, it silently rewrites an issue body with no human review step.
+- **Blast radius:** All open issues could be rewritten in a single workflow run.
+- **Mitigation:** Prompt explicitly constrains scope to concrete contradictions (wrong field names, resolved blockers) and instructs the LLM to do nothing if no issues are stale. Workflow permissions are scoped to `issues: write` only (no `contents: write`).
+- **Monitoring:** Review `docs-issue-sync` run logs after every docs push; revert any incorrect edits via `gh issue edit`.
+
 **R6 — Frontend WsEvent schema alignment (FE2 prerequisite)**
 - **Risk:** The frontend canvas (issue #10) subscribes to `eventBus` using the canonical `WsEvent` type from `@x-pet/shared`. The real WS client (issue FE2) must emit events using the same field names (`from_pet_id`, `to_pet_id`, `turns`, `token`, `amount`).
 - **Impact:** Silent runtime breakage — `e.data.from_pet_id` returns `undefined` if the WS client sends `from` instead.


### PR DESCRIPTION
closes #55

## Summary
- `docs-issue-sync`: On every push to `docs/**` on main, scans all open issues for stale references (wrong field names, resolved blockers, contradicted design) and updates them via Claude Code Action.
- `issue-close-sync`: When an issue is closed, finds all open issues that reference it in a "Blocked By" section, marks the dependency resolved, and removes the `blocked` label if it was the only remaining blocker.

## Changes in this revision
- Pinned `actions/checkout` from `v6` (non-existent) to `v4` (confirmed stable)
- Added R9 risk entry to `docs/risks.md` documenting LLM write-access blast radius and mitigation