### PR TITLE
chore(ci): check drizzle migrations are fully committed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v5
 
@@ -28,3 +28,11 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Check migrations are committed
+        run: |
+          pnpm --filter @x-pet/backend db:generate
+          git diff --exit-code -- packages/backend/drizzle/
+        env:
+          # drizzle-kit generate only needs the schema file, no real DB connection
+          DATABASE_URL: postgresql://dummy:dummy@localhost/dummy


### PR DESCRIPTION
## Problem

After \`drizzle-kit generate\`, agents (and humans) sometimes only stage the \`.sql\` file and miss \`drizzle/meta/\`. The PR passes CI but the migration is broken on remote.

## Fix

Add a CI step that re-runs \`db:generate\` and asserts \`git diff --exit-code\` on \`drizzle/\`. If any generated file is missing from the commit, CI fails.

Also pins \`actions/checkout\` from \`v6\` (non-existent) to \`v4\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)