### PR TITLE
chore: enforce drizzle migration completeness (CI + dev hook)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command' | grep -q 'db:generate\\|drizzle-kit generate' && git -C \"$(git rev-parse --show-toplevel)\" add packages/backend/drizzle/ || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v5
 
@@ -28,3 +28,10 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Check migrations are committed
+        run: |
+          pnpm --filter @x-pet/backend db:generate
+          git diff --exit-code -- packages/backend/drizzle/
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost/dummy


### PR DESCRIPTION
## Summary

- Pin `actions/checkout@v4` (was `@v6`, non-existent tag)
- Add **Check migrations are committed** CI step: re-runs `db:generate` and asserts `git diff --exit-code` on `packages/backend/drizzle/` — fails PR if any generated file is missing
- Add `.claude/settings.json` with a `PostToolUse` hook that auto-stages `drizzle/` after any `db:generate` / `drizzle-kit generate` Bash command

## Test plan

- [ ] Pipe-tested hook command — fires on `db:generate`, skips on unrelated commands ✓
- [ ] Verify CI step passes on clean branch (no pending generate diff)
- [ ] Verify CI step fails if a migration file is generated but not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)