### PR TITLE
fix(ci): replace claude-code-action with direct CLI for push events

### DIFF
--- a/.github/workflows/docs-issue-sync.yml
+++ b/.github/workflows/docs-issue-sync.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
       issues: write
@@ -21,31 +19,38 @@ jobs:
         with:
           fetch-depth: 2
 
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install Claude Code CLI
+        run: bun add -g @anthropic-ai/claude-code
+
       - name: Sync issues with updated docs
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: --allowedTools "Bash,Read,Glob"
-          prompt: |
-            A push to main just changed one or more files under docs/.
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          cat > /tmp/sync-prompt.txt << 'PROMPT'
+          A push to main just changed one or more files under docs/.
 
-            1. Find which docs changed:
-               git diff HEAD~1 HEAD --name-only -- 'docs/**'
+          1. Find which docs changed:
+             git diff HEAD~1 HEAD --name-only -- 'docs/**'
 
-            2. For each changed doc, read it in full.
+          2. For each changed doc, read it in full.
 
-            3. List all open GitHub issues:
-               gh issue list --repo ${{ github.repository }} --state open --limit 100 --json number,title,body,labels
+          3. List all open GitHub issues:
+             gh issue list --repo $GITHUB_REPOSITORY --state open --limit 100 --json number,title,body,labels
 
-            4. For each open issue, check whether its body references any design decisions, field names, env vars, or approach choices that now contradict what the changed docs say.
+          4. For each open issue, check whether its body references any design decisions, field names, env vars, or approach choices that now contradict what the changed docs say.
 
-            5. For every stale issue found, update it:
-               - Edit the body to reflect the current design (gh issue edit <N> --repo ${{ github.repository }} --body "...")
-               - If the issue was blocked by a dependency that the doc change resolves, remove the "blocked" label (gh issue edit <N> --repo ${{ github.repository }} --remove-label "blocked")
-               - Add a comment explaining what changed and why:
-                 gh issue comment <N> --repo ${{ github.repository }} --body "Updated by docs-issue-sync: <doc file> changed on main. <one sentence explaining what was stale and what was corrected>"
+          5. For every stale issue found, update it:
+             - Edit the body to reflect the current design (gh issue edit <N> --repo $GITHUB_REPOSITORY --body "...")
+             - If the issue was blocked by a dependency that the doc change resolves, remove the "blocked" label (gh issue edit <N> --repo $GITHUB_REPOSITORY --remove-label "blocked")
+             - Add a comment explaining what changed and why:
+               gh issue comment <N> --repo $GITHUB_REPOSITORY --body "Updated by docs-issue-sync: <doc file> changed on main. <one sentence explaining what was stale and what was corrected>"
 
-            6. If no issues are stale, do nothing.
+          6. If no issues are stale, do nothing.
 
-            Focus only on concrete contradictions (wrong field names, wrong approach, resolved blockers). Do not rewrite style or add detail that isn't already in the doc.
+          Focus only on concrete contradictions (wrong field names, wrong approach, resolved blockers). Do not rewrite style or add detail that isn't already in the doc.
+          PROMPT
+          claude -p --allowedTools "Bash,Read,Glob" "$(cat /tmp/sync-prompt.txt)"


### PR DESCRIPTION
## Summary
- `claude-code-action@v1` only handles PR/issue events — running it on `push` throws `Unsupported event type: push`
- Replace with: install `@anthropic-ai/claude-code` via bun, then run `claude -p` directly with the same prompt and `--allowedTools`
- Auth switches from action input to `CLAUDE_CODE_OAUTH_TOKEN` env var (same secret, already configured)

## Test plan
- [ ] Merge this PR and push a change to `docs/` — workflow should complete without the `Unsupported event type` error
- [ ] Verify Claude CLI runs and outputs the sync result

closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)