### PR TITLE
feat(frontend): DOM UI overlay — nameplate, chat, toasts, stats

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -7,7 +7,7 @@
     <style>
       *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
       html, body { width: 100%; height: 100%; overflow: hidden; background: #1a1a2e; }
-      #canvas { width: 100%; height: 100%; }
+      #canvas { width: 100%; height: 100%; position: relative; }
     </style>
   </head>
   <body>

--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -3,6 +3,7 @@ import { PetRoom } from './canvas/PetRoom';
 import { MockEvents } from './canvas/MockEvents';
 import { eventBus } from './ws/eventBus';
 import { WsClient, buildWsUrl } from './ws/WsClient';
+import { initUI } from './ui';
 
 async function main(): Promise<void> {
   const mount = document.getElementById('canvas');
@@ -18,6 +19,7 @@ async function main(): Promise<void> {
   });
 
   mount.appendChild(app.canvas);
+  initUI(mount);
 
   const room = new PetRoom(app);
   app.stage.addChild(room, room.overlays);

--- a/packages/frontend/src/ui/ChatLog.ts
+++ b/packages/frontend/src/ui/ChatLog.ts
@@ -1,0 +1,73 @@
+const MAX_ENTRIES = 50;
+
+interface ChatEntry {
+  speaker: string;
+  text: string;
+  time: Date;
+}
+
+/** Scrollable chat log panel — auto-scrolls, max 50 entries. */
+export class ChatLog {
+  readonly el: HTMLDivElement;
+  private readonly messages: HTMLDivElement;
+  private count = 0;
+
+  constructor() {
+    this.el = document.createElement('div');
+    this.el.id = 'chat-log';
+    this.el.classList.add('ui-panel');
+
+    const header = document.createElement('div');
+    header.className = 'chat-header';
+    header.textContent = 'Chat';
+
+    this.messages = document.createElement('div');
+    this.messages.className = 'chat-messages';
+
+    this.el.append(header, this.messages);
+  }
+
+  add(entry: ChatEntry): void {
+    const row = document.createElement('div');
+    row.className = 'chat-entry';
+
+    const time = document.createElement('span');
+    time.className = 'chat-time';
+    time.textContent = this.formatTime(entry.time);
+
+    const speaker = document.createElement('span');
+    speaker.className = 'chat-speaker';
+    speaker.textContent = entry.speaker;
+
+    const text = document.createElement('span');
+    text.className = 'chat-text';
+    text.textContent = entry.text;
+
+    row.append(time, speaker, text);
+    this.messages.appendChild(row);
+    this.count++;
+
+    // Trim oldest entries beyond MAX_ENTRIES
+    while (this.count > MAX_ENTRIES && this.messages.firstChild) {
+      this.messages.removeChild(this.messages.firstChild);
+      this.count--;
+    }
+
+    // Auto-scroll to bottom
+    this.messages.scrollTop = this.messages.scrollHeight;
+  }
+
+  addSpeak(petId: string, message: string): void {
+    this.add({ speaker: petId, text: message, time: new Date() });
+  }
+
+  addVisit(fromPetId: string, turns: { speaker_pet_id: string; line: string }[]): void {
+    for (const turn of turns) {
+      this.add({ speaker: turn.speaker_pet_id, text: turn.line, time: new Date() });
+    }
+  }
+
+  private formatTime(d: Date): string {
+    return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  }
+}

--- a/packages/frontend/src/ui/Nameplate.ts
+++ b/packages/frontend/src/ui/Nameplate.ts
@@ -1,0 +1,47 @@
+/** Pet nameplate — name, status indicator, truncated wallet address. */
+export class Nameplate {
+  readonly el: HTMLDivElement;
+  private readonly statusDot: HTMLSpanElement;
+  private readonly nameEl: HTMLSpanElement;
+  private readonly walletEl: HTMLSpanElement;
+
+  constructor(
+    name = 'My Pet',
+    wallet = '0x0000...0000',
+    status: 'online' | 'starting' | 'offline' = 'online',
+  ) {
+    this.el = document.createElement('div');
+    this.el.id = 'pet-nameplate';
+    this.el.classList.add('ui-panel');
+
+    this.statusDot = document.createElement('span');
+    this.statusDot.className = 'pet-status';
+    this.statusDot.dataset.status = status;
+
+    this.nameEl = document.createElement('span');
+    this.nameEl.className = 'pet-name';
+    this.nameEl.textContent = name;
+
+    this.walletEl = document.createElement('span');
+    this.walletEl.className = 'pet-wallet';
+    this.walletEl.textContent = wallet;
+
+    this.el.append(this.statusDot, this.nameEl, this.walletEl);
+  }
+
+  setName(name: string): void {
+    this.nameEl.textContent = name;
+  }
+
+  setWallet(address: string): void {
+    if (address.length > 14) {
+      this.walletEl.textContent = `${address.slice(0, 6)}...${address.slice(-4)}`;
+    } else {
+      this.walletEl.textContent = address;
+    }
+  }
+
+  setStatus(status: 'online' | 'starting' | 'offline'): void {
+    this.statusDot.dataset.status = status;
+  }
+}

--- a/packages/frontend/src/ui/StatBars.ts
+++ b/packages/frontend/src/ui/StatBars.ts
@@ -1,0 +1,59 @@
+interface Stat {
+  key: string;
+  label: string;
+  fill: HTMLDivElement;
+  valueEl: HTMLSpanElement;
+}
+
+/** Animated stat bars — hunger, mood, affection with smooth transitions. */
+export class StatBars {
+  readonly el: HTMLDivElement;
+  private readonly stats: Stat[];
+
+  constructor() {
+    this.el = document.createElement('div');
+    this.el.id = 'stat-bars';
+    this.el.classList.add('ui-panel');
+
+    const defs: { key: string; label: string; icon: string }[] = [
+      { key: 'hunger', label: 'Hunger', icon: '🍎' },
+      { key: 'mood', label: 'Mood', icon: '😊' },
+      { key: 'affection', label: 'Love', icon: '💗' },
+    ];
+
+    this.stats = defs.map((def) => {
+      const item = document.createElement('div');
+      item.className = 'stat-item';
+
+      const label = document.createElement('span');
+      label.className = 'stat-label';
+      label.textContent = `${def.icon} ${def.label}`;
+
+      const track = document.createElement('div');
+      track.className = 'stat-track';
+
+      const fill = document.createElement('div');
+      fill.className = `stat-fill ${def.key}`;
+      fill.style.width = '70%';
+      track.appendChild(fill);
+
+      const valueEl = document.createElement('span');
+      valueEl.className = 'stat-value';
+      valueEl.textContent = '70';
+
+      item.append(label, track, valueEl);
+      this.el.appendChild(item);
+
+      return { key: def.key, label: def.label, fill, valueEl };
+    });
+  }
+
+  update(hunger: number, mood: number, affection: number): void {
+    const values = [hunger, mood, affection];
+    for (let i = 0; i < this.stats.length; i++) {
+      const v = Math.round(Math.max(0, Math.min(100, values[i])));
+      this.stats[i].fill.style.width = `${v}%`;
+      this.stats[i].valueEl.textContent = String(v);
+    }
+  }
+}

--- a/packages/frontend/src/ui/Toasts.ts
+++ b/packages/frontend/src/ui/Toasts.ts
@@ -1,0 +1,33 @@
+const DISMISS_MS = 4000;
+const ANIM_OUT_MS = 300;
+
+/** Toast notification stack — slide-in, auto-dismiss after 4 s. */
+export class Toasts {
+  readonly el: HTMLDivElement;
+
+  constructor() {
+    this.el = document.createElement('div');
+    this.el.id = 'toast-container';
+  }
+
+  show(message: string, type: 'gift' | 'friend' = 'gift'): void {
+    const toast = document.createElement('div');
+    toast.className = `toast ui-panel toast-${type}`;
+    toast.textContent = message;
+
+    this.el.appendChild(toast);
+
+    setTimeout(() => {
+      toast.classList.add('toast-out');
+      setTimeout(() => toast.remove(), ANIM_OUT_MS);
+    }, DISMISS_MS);
+  }
+
+  gift(from: string, to: string, amount: string, token: string): void {
+    this.show(`🎁 ${from} sent ${amount} ${token} to ${to}`, 'gift');
+  }
+
+  friendUnlocked(petId: string): void {
+    this.show(`💛 You and ${petId} are now friends!`, 'friend');
+  }
+}

--- a/packages/frontend/src/ui/index.ts
+++ b/packages/frontend/src/ui/index.ts
@@ -1,0 +1,41 @@
+import { eventBus } from '../ws/eventBus';
+import { Nameplate } from './Nameplate';
+import { ChatLog } from './ChatLog';
+import { Toasts } from './Toasts';
+import { StatBars } from './StatBars';
+import './styles.css';
+
+/** Initialize the DOM UI overlay and wire it to the WS eventBus. */
+export function initUI(mount: HTMLElement): void {
+  const overlay = document.createElement('div');
+  overlay.id = 'ui-overlay';
+
+  const nameplate = new Nameplate('My Pet', '0x1234...5678', 'online');
+  const chatLog = new ChatLog();
+  const toasts = new Toasts();
+  const statBars = new StatBars();
+
+  overlay.append(nameplate.el, chatLog.el, toasts.el, statBars.el);
+  mount.appendChild(overlay);
+
+  // Wire eventBus → UI components
+  eventBus.on('pet.state', (e) => {
+    statBars.update(e.data.hunger, e.data.mood, e.data.affection);
+  });
+
+  eventBus.on('pet.speak', (e) => {
+    chatLog.addSpeak(e.data.pet_id, e.data.message);
+  });
+
+  eventBus.on('social.visit', (e) => {
+    chatLog.addVisit(e.data.from_pet_id, e.data.turns);
+  });
+
+  eventBus.on('social.gift', (e) => {
+    toasts.gift(e.data.from_pet_id, e.data.to_pet_id, e.data.amount, e.data.token);
+  });
+
+  eventBus.on('friend.unlocked', (e) => {
+    toasts.friendUnlocked(e.data.pet_id);
+  });
+}

--- a/packages/frontend/src/ui/styles.css
+++ b/packages/frontend/src/ui/styles.css
@@ -1,0 +1,311 @@
+/* ── x-pet DOM UI overlay ──────────────────────────────────────────── */
+/* Cozy pastel style matching Sprout Lands by Cup Nooble               */
+
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Inter:wght@400;600&display=swap');
+
+:root {
+  --ui-green: #6b8f4e;
+  --ui-green-light: #a3c585;
+  --ui-brown: #8b6f47;
+  --ui-brown-light: #c4a882;
+  --ui-yellow: #e8c547;
+  --ui-yellow-warm: #f5dfa0;
+  --ui-cream: #fef6e0;
+  --ui-pink: #e8a0b4;
+  --ui-panel-bg: rgba(254, 246, 224, 0.88);
+  --ui-panel-border: #c4a882;
+  --ui-text: #4a3728;
+  --ui-text-muted: #8b7355;
+  --ui-shadow: rgba(107, 83, 54, 0.25);
+  --ui-font-pixel: 'Press Start 2P', monospace;
+  --ui-font-body: 'Inter', system-ui, sans-serif;
+}
+
+/* ── Shared panel styling ─────────────────────────────────────────── */
+.ui-panel {
+  background: var(--ui-panel-bg);
+  border: 2px solid var(--ui-panel-border);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px var(--ui-shadow), inset 0 1px 0 rgba(255,255,255,0.5);
+  color: var(--ui-text);
+  font-family: var(--ui-font-body);
+}
+
+/* ── Overlay container ────────────────────────────────────────────── */
+#ui-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  gap: 8px;
+  overflow: hidden;
+}
+
+#ui-overlay * {
+  pointer-events: auto;
+}
+
+/* ── Pet nameplate ────────────────────────────────────────────────── */
+#pet-nameplate {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  font-size: 12px;
+  pointer-events: none;
+}
+
+#pet-nameplate .pet-name {
+  font-family: var(--ui-font-pixel);
+  font-size: 11px;
+  color: var(--ui-brown);
+}
+
+#pet-nameplate .pet-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ui-green);
+  box-shadow: 0 0 4px var(--ui-green-light);
+  flex-shrink: 0;
+}
+
+#pet-nameplate .pet-status[data-status="offline"] {
+  background: #b0a090;
+  box-shadow: none;
+}
+
+#pet-nameplate .pet-status[data-status="starting"] {
+  background: var(--ui-yellow);
+  box-shadow: 0 0 4px var(--ui-yellow-warm);
+  animation: pulse-status 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse-status {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+#pet-nameplate .pet-wallet {
+  font-size: 10px;
+  color: var(--ui-text-muted);
+  font-family: var(--ui-font-body);
+}
+
+/* ── Chat log ─────────────────────────────────────────────────────── */
+#chat-log {
+  position: absolute;
+  right: 12px;
+  top: 50px;
+  width: 260px;
+  max-height: 45vh;
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  overflow: hidden;
+}
+
+#chat-log .chat-header {
+  font-family: var(--ui-font-pixel);
+  font-size: 9px;
+  color: var(--ui-brown);
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--ui-brown-light);
+  flex-shrink: 0;
+}
+
+#chat-log .chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+#chat-log .chat-messages::-webkit-scrollbar {
+  width: 5px;
+}
+
+#chat-log .chat-messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+#chat-log .chat-messages::-webkit-scrollbar-thumb {
+  background: var(--ui-brown-light);
+  border-radius: 3px;
+}
+
+.chat-entry {
+  padding: 4px 6px;
+  border-radius: 4px;
+  line-height: 1.4;
+  animation: chat-slide-in 0.2s ease-out;
+}
+
+.chat-entry:nth-child(odd) {
+  background: rgba(163, 197, 133, 0.18);
+}
+
+.chat-entry .chat-time {
+  font-size: 9px;
+  color: var(--ui-text-muted);
+  margin-right: 4px;
+}
+
+.chat-entry .chat-speaker {
+  font-weight: 600;
+  color: var(--ui-green);
+  margin-right: 4px;
+}
+
+.chat-entry .chat-text {
+  color: var(--ui-text);
+}
+
+@keyframes chat-slide-in {
+  from { opacity: 0; transform: translateX(12px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* ── Toast notifications ──────────────────────────────────────────── */
+#toast-container {
+  position: absolute;
+  bottom: 120px;
+  right: 12px;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 6px;
+  max-width: 280px;
+}
+
+.toast {
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  animation: toast-in 0.3s ease-out;
+  border-left: 3px solid var(--ui-yellow);
+}
+
+.toast.toast-gift {
+  border-left-color: var(--ui-yellow);
+}
+
+.toast.toast-friend {
+  border-left-color: var(--ui-pink);
+}
+
+.toast.toast-out {
+  animation: toast-out 0.3s ease-in forwards;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(40px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes toast-out {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(40px); }
+}
+
+/* ── Stat bars ────────────────────────────────────────────────────── */
+#stat-bars {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 16px;
+  padding: 8px 16px;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  min-width: 80px;
+}
+
+.stat-label {
+  font-family: var(--ui-font-pixel);
+  font-size: 7px;
+  color: var(--ui-brown);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.stat-track {
+  width: 100%;
+  height: 10px;
+  background: rgba(139, 111, 71, 0.2);
+  border-radius: 5px;
+  overflow: hidden;
+  border: 1px solid var(--ui-brown-light);
+}
+
+.stat-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.6s ease-out;
+  width: 70%;
+}
+
+.stat-fill.hunger  { background: linear-gradient(90deg, #e8c547, #f5dfa0); }
+.stat-fill.mood    { background: linear-gradient(90deg, #6b8f4e, #a3c585); }
+.stat-fill.affection { background: linear-gradient(90deg, #e8a0b4, #f0c8d8); }
+
+.stat-value {
+  font-size: 10px;
+  color: var(--ui-text-muted);
+  font-family: var(--ui-font-body);
+}
+
+/* ── Mobile responsive ────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  #chat-log {
+    position: absolute;
+    right: 6px;
+    left: 6px;
+    top: auto;
+    bottom: 100px;
+    width: auto;
+    max-height: 30vh;
+  }
+
+  #stat-bars {
+    gap: 8px;
+    padding: 6px 10px;
+    bottom: 6px;
+  }
+
+  .stat-item {
+    min-width: 60px;
+  }
+
+  .stat-label {
+    font-size: 6px;
+  }
+
+  #toast-container {
+    right: 6px;
+    left: 6px;
+    bottom: auto;
+    top: 50px;
+    max-width: none;
+  }
+
+  #pet-nameplate {
+    padding: 4px 10px;
+    font-size: 10px;
+  }
+
+  #pet-nameplate .pet-name {
+    font-size: 9px;
+  }
+}


### PR DESCRIPTION
## Summary
- **Pet nameplate** — name, online/starting/offline status dot, truncated wallet address (top-center)
- **Chat log panel** — scrollable right-side panel with timestamps, speaker labels, auto-scroll, max 50 entries, styled scrollbar
- **Toast notifications** — bottom-right stack for gift/friend events, slide-in animation, 4s auto-dismiss
- **Stat bars** — hunger (amber), mood (green), affection (pink) with CSS-animated fills and value labels
- All components wired to WS `eventBus` — works with MockEvents and real WS client
- Mobile-responsive layout (single-column on ≤600px)
- Warm pastel cozy style matching Sprout Lands assets (earthy greens, browns, warm yellows) — Press Start 2P headers, Inter body

Closes #17

## Test plan
- [ ] Run `npm run dev` in `packages/frontend/`, verify overlay renders on PixiJS canvas
- [ ] Confirm MockEvents drive chat log entries, stat bar updates, and toast popups
- [ ] Resize browser to ≤600px width — verify mobile layout
- [ ] Verify chat log caps at 50 entries and auto-scrolls
- [ ] Verify toasts auto-dismiss after ~4s with slide-out animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)