### PR TITLE
feat(auth): replace custom auth endpoints with Supabase Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,9 @@ ONCHAIN_OS_API_URL=https://www.okx.com/priapi/v1/onchain-os
 X_LAYER_RPC_URL=https://rpc.xlayer.tech
 X402_FACILITATOR_URL=https://facilitator.x402.org
 PORT=3000
-JWT_SECRET=your-jwt-secret
+# Supabase — used to verify JWTs via supabase.auth.getUser() on the server
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # Optional
 TELEGRAM_BOT_TOKEN=
 DOCKER_HOST=

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -10,8 +10,6 @@ Defines the full contract between backend and frontend for x-pet.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/api/auth/register` | Create account (email + password) |
-| POST | `/api/auth/login` | Sign in, returns JWT |
 | GET | `/api/users/me` | Current user profile |
 | POST | `/api/pets` | Create a new pet |
 | GET | `/api/pets` | List all pets for the current user |
@@ -51,76 +49,13 @@ Base URL: `https://<host>/api`
 
 All endpoints return `Content-Type: application/json`.
 
-Protected endpoints require `Authorization: Bearer <token>` header.
-
----
-
-### POST /api/auth/register
-
-Create a new user account.
-
-**Request body**
-
-```typescript
-{
-  email: string;
-  password: string; // min 8 chars
-}
-```
-
-**Response — 201 Created**
-
-```typescript
-{
-  id: string;    // user uuid
-  email: string;
-  token: string; // JWT for subsequent requests
-}
-```
-
-**Error codes**
-
-| Status | code               | Condition                       |
-|--------|--------------------|---------------------------------|
-| 400    | `VALIDATION_ERROR` | Invalid email or short password |
-| 409    | `CONFLICT`         | Email already registered        |
-
----
-
-### POST /api/auth/login
-
-Sign in with email and password.
-
-**Request body**
-
-```typescript
-{
-  email: string;
-  password: string;
-}
-```
-
-**Response — 200 OK**
-
-```typescript
-{
-  id: string;    // user uuid
-  email: string;
-  token: string; // JWT
-}
-```
-
-**Error codes**
-
-| Status | code           | Condition               |
-|--------|----------------|-------------------------|
-| 401    | `UNAUTHORIZED` | Wrong email or password |
+Protected endpoints require `Authorization: Bearer <supabase-jwt>` header. The backend verifies the token by calling `supabase.auth.getUser(token)` using the Supabase server client (initialized with `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`). Registration and login are handled entirely by the Supabase client SDK — there are no custom auth endpoints on the backend.
 
 ---
 
 ### GET /api/users/me
 
-Return the authenticated user's profile. Requires auth.
+Return the authenticated user's profile. Wraps `supabase.auth.getUser()`. Requires auth.
 
 **Response — 200 OK**
 
@@ -413,7 +348,7 @@ Fetch the AI-generated daily summary for a pet. Requires auth.
 ws://<host>/ws?token=<jwt>
 ```
 
-- `token` — the JWT obtained from `/api/auth/login` or `/api/auth/register`. The server verifies the token and derives `owner_id` from it; unauthenticated connections are rejected with close code `4001`.
+- `token` — the Supabase JWT obtained via the Supabase client SDK. The server verifies the token via `supabase.auth.getUser(token)` and derives `owner_id` from it; unauthenticated connections are rejected with close code `4001`.
 - The server streams events for all pets owned by the authenticated user.
 - The server sends JSON-encoded `WsEvent` messages (server → client only).
 - The client does not send messages over this connection.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,7 +1,6 @@
 // Types
 export type {
   User,
-  AuthResponse,
   Pet,
   PetCreate,
   PetState,
@@ -21,8 +20,6 @@ export type {
 
 // Schemas
 export {
-  RegisterSchema,
-  LoginSchema,
   PetCreateSchema,
   PetIdParamSchema,
   PetEventsQuerySchema,

--- a/packages/shared/src/schemas/pet.ts
+++ b/packages/shared/src/schemas/pet.ts
@@ -1,16 +1,5 @@
 import { z } from 'zod';
 
-// Auth
-export const RegisterSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-});
-
-export const LoginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1),
-});
-
 // Pets
 export const PetCreateSchema = z.object({
   soul_prompt: z.string().min(1),

--- a/packages/shared/src/types/pet.ts
+++ b/packages/shared/src/types/pet.ts
@@ -6,13 +6,6 @@ export type User = {
   email: string;
 };
 
-// Auth response (register / login)
-export type AuthResponse = {
-  id: string;
-  email: string;
-  token: string;
-};
-
 // Pet — one row per pet (DB record)
 export type Pet = {
   id: string;


### PR DESCRIPTION
## Summary

- Remove `POST /api/auth/register` and `POST /api/auth/login` from `docs/api-contracts.md` — handled by Supabase client SDK
- Update `GET /api/users/me` to note it wraps `supabase.auth.getUser()`
- Update auth note on all protected endpoints and WS connection to reference Supabase JWT verification via `supabase.auth.getUser(token)` with Supabase server client
- Add `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` to `.env.example`; remove `JWT_SECRET`
- Remove `RegisterSchema`, `LoginSchema` from `packages/shared/src/schemas/pet.ts` and their exports from `index.ts`
- Remove `AuthResponse` type from `packages/shared/src/types/pet.ts` and its export from `index.ts`

**Note:** Fastify auth hook implementation is handled in PR #70 (issue #12). Issue #56 will be fully closed once #12 merges.

## Test plan

- [ ] Verify `docs/api-contracts.md` no longer references `/api/auth/register` or `/api/auth/login`
- [ ] Verify `packages/shared` builds without errors (`tsc --noEmit`)
- [ ] Confirm no existing backend code imports `RegisterSchema`, `LoginSchema`, or `AuthResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)