### PR TITLE
feat(frontend): Playwright screenshot tool for canvas verification

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "screenshot": "tsx scripts/screenshot.ts"
   },
   "dependencies": {
     "@x-pet/shared": "workspace:*",
@@ -17,6 +18,8 @@
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "eslint": "^10.1.0",
+    "playwright": "^1.58.2",
+    "tsx": "^4.7.0",
     "typescript": "^5.8.0",
     "vite": "^6.2.0"
   }

--- a/packages/frontend/scripts/screenshot.ts
+++ b/packages/frontend/scripts/screenshot.ts
@@ -1,0 +1,33 @@
+/**
+ * Canvas visual verification screenshot tool.
+ *
+ * Usage:
+ *   # Terminal 1 — start dev server
+ *   pnpm --filter @x-pet/frontend dev
+ *
+ *   # Terminal 2 — capture screenshot
+ *   pnpm --filter @x-pet/frontend screenshot
+ *   # → /tmp/x-pet-render.png ready for Read tool multimodal review
+ *
+ * Env vars:
+ *   SCREENSHOT_DELAY_MS  — ms to wait for PixiJS to initialize (default: 2000)
+ *   SCREENSHOT_URL       — URL to navigate to (default: http://localhost:5173)
+ *   SCREENSHOT_OUTPUT    — output path (default: /tmp/x-pet-render.png)
+ */
+
+import { chromium } from "playwright";
+
+const url = process.env.SCREENSHOT_URL ?? "http://localhost:5173";
+const output = process.env.SCREENSHOT_OUTPUT ?? "/tmp/x-pet-render.png";
+const delay = Number(process.env.SCREENSHOT_DELAY_MS ?? 2000);
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+await page.goto(url, { waitUntil: "networkidle" });
+await page.waitForTimeout(delay);
+await page.screenshot({ path: output, fullPage: true });
+
+await browser.close();
+
+console.log(`Screenshot saved to ${output}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,12 @@ importers:
       eslint:
         specifier: ^10.1.0
         version: 10.1.0
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -1745,6 +1751,11 @@ packages:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2198,6 +2209,16 @@ packages:
 
   pixi.js@8.17.1:
     resolution: {integrity: sha512-OB4TpZHrP5RYy+7FqmFrAc0IHRhfOoNIfF4sVeinvK3aG1r2pYrSMneJAKi9+WvGKC70Dj7GEpZ2OZGB6o/xdg==}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4128,6 +4149,9 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4610,6 +4634,14 @@ snapshots:
       ismobilejs: 1.1.1
       parse-svg-path: 0.1.2
       tiny-lru: 11.4.7
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- Adds `packages/frontend/scripts/screenshot.ts` — launches headless Chromium, navigates to `http://localhost:5173`, waits for PixiJS to initialize, saves screenshot to `/tmp/x-pet-render.png`
- Installs `playwright` and `tsx` as devDependencies in `packages/frontend`
- Adds `"screenshot": "tsx scripts/screenshot.ts"` script to `packages/frontend/package.json`
- Supports `SCREENSHOT_DELAY_MS` (default 2000ms), `SCREENSHOT_URL`, and `SCREENSHOT_OUTPUT` env vars

## Usage

```bash
# Terminal 1 — start dev server
pnpm --filter @x-pet/frontend dev

# Terminal 2 — capture screenshot
pnpm --filter @x-pet/frontend screenshot
# → /tmp/x-pet-render.png ready for Read tool multimodal review
```

## Test plan

- [ ] Start dev server (`pnpm --filter @x-pet/frontend dev`)
- [ ] Run `pnpm --filter @x-pet/frontend screenshot` — verify `/tmp/x-pet-render.png` is created
- [ ] Verify screenshot shows the PixiJS canvas with pet sprites rendered (not a blank frame)
- [ ] Test `SCREENSHOT_DELAY_MS=5000 pnpm --filter @x-pet/frontend screenshot` for env var override

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)