### PR TITLE
fix(ci): pipe prompt from file to avoid YAML heredoc indentation issue

### DIFF
--- a/.github/prompts/docs-issue-sync.md
+++ b/.github/prompts/docs-issue-sync.md
@@ -1,0 +1,21 @@
+A push to main just changed one or more files under docs/.
+
+1. Find which docs changed:
+   git diff HEAD~1 HEAD --name-only -- 'docs/**'
+
+2. For each changed doc, read it in full.
+
+3. List all open GitHub issues:
+   gh issue list --repo $GITHUB_REPOSITORY --state open --limit 100 --json number,title,body,labels
+
+4. For each open issue, check whether its body references any design decisions, field names, env vars, or approach choices that now contradict what the changed docs say.
+
+5. For every stale issue found, update it:
+   - Edit the body to reflect the current design (gh issue edit <N> --repo $GITHUB_REPOSITORY --body "...")
+   - If the issue was blocked by a dependency that the doc change resolves, remove the "blocked" label (gh issue edit <N> --repo $GITHUB_REPOSITORY --remove-label "blocked")
+   - Add a comment explaining what changed and why:
+     gh issue comment <N> --repo $GITHUB_REPOSITORY --body "Updated by docs-issue-sync: <doc file> changed on main. <one sentence explaining what was stale and what was corrected>"
+
+6. If no issues are stale, do nothing.
+
+Focus only on concrete contradictions (wrong field names, wrong approach, resolved blockers). Do not rewrite style or add detail that isn't already in the doc.

--- a/.github/workflows/docs-issue-sync.yml
+++ b/.github/workflows/docs-issue-sync.yml
@@ -29,28 +29,4 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          cat > /tmp/sync-prompt.txt << 'PROMPT'
-          A push to main just changed one or more files under docs/.
-
-          1. Find which docs changed:
-             git diff HEAD~1 HEAD --name-only -- 'docs/**'
-
-          2. For each changed doc, read it in full.
-
-          3. List all open GitHub issues:
-             gh issue list --repo $GITHUB_REPOSITORY --state open --limit 100 --json number,title,body,labels
-
-          4. For each open issue, check whether its body references any design decisions, field names, env vars, or approach choices that now contradict what the changed docs say.
-
-          5. For every stale issue found, update it:
-             - Edit the body to reflect the current design (gh issue edit <N> --repo $GITHUB_REPOSITORY --body "...")
-             - If the issue was blocked by a dependency that the doc change resolves, remove the "blocked" label (gh issue edit <N> --repo $GITHUB_REPOSITORY --remove-label "blocked")
-             - Add a comment explaining what changed and why:
-               gh issue comment <N> --repo $GITHUB_REPOSITORY --body "Updated by docs-issue-sync: <doc file> changed on main. <one sentence explaining what was stale and what was corrected>"
-
-          6. If no issues are stale, do nothing.
-
-          Focus only on concrete contradictions (wrong field names, wrong approach, resolved blockers). Do not rewrite style or add detail that isn't already in the doc.
-          PROMPT
-          claude -p --allowedTools "Bash,Read,Glob" "$(cat /tmp/sync-prompt.txt)"
+        run: claude --print --allowedTools "Bash,Read,Glob" < .github/prompts/docs-issue-sync.md


### PR DESCRIPTION
## Summary
- YAML `run: |` indents the script body, so the heredoc terminator `PROMPT` never lands at column 0 — shell never closes the heredoc, file stays empty, `claude -p` fails with `Input must be provided either through stdin or as a prompt argument`
- Move the prompt to `.github/prompts/docs-issue-sync.md` and pipe it via stdin: `claude --print --allowedTools "Bash,Read,Glob" < .github/prompts/docs-issue-sync.md`

## Test plan
- [ ] Merge and push a change to `docs/` — workflow should complete without prompt error

closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)