### PR TITLE
feat(social): visit engine, affection, friend.unlocked, diary endpoint

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -6,6 +6,7 @@ import './ws/wsEmitter.js'; // subscribes tickBus events → WebSocket clients
 import { registerTickRoute } from './runtime/tick-route.js';
 import { registerPetRoutes } from './api/petRoutes.js';
 import { registerChatRoute } from './api/chatRoute.js';
+import { registerDiaryRoute } from './social/diary.js';
 import { generateSoulMd } from './runtime/soul-generator.js';
 import { generateSkillMd } from './runtime/skill-generator.js';
 import { tickBus } from './runtime/tick-bus.js';
@@ -20,6 +21,7 @@ await registerPetRoutes(fastify, { generateSoulMd, generateSkillMd });
 await registerChatRoute(fastify, {
   emitOwnerEvent: (ownerId, event) => tickBus.emit('ownerEvent', ownerId, event),
 });
+await registerDiaryRoute(fastify);
 
 const port = Number(process.env.PORT ?? 3001);
 await fastify.listen({ port, host: '0.0.0.0' });

--- a/packages/backend/src/runtime/mock-tick.ts
+++ b/packages/backend/src/runtime/mock-tick.ts
@@ -5,6 +5,7 @@ import { db } from '../db/client.js';
 import { pets, social_events } from '../db/schema.js';
 import { tickBus } from './tick-bus.js';
 import { tickTools } from './tick-tools.js';
+import { executeVisit } from '../social/visit.js';
 
 const anthropic = new Anthropic();
 
@@ -162,20 +163,7 @@ export async function executeTick(petId: string): Promise<{ action: string }> {
   switch (toolUse.name) {
     case 'visit_pet': {
       const { target_pet_id, greeting } = VisitPetInput.parse(toolUse.input);
-      await db.insert(social_events).values({
-        from_pet_id: petId,
-        to_pet_id: target_pet_id,
-        type: 'visit',
-        payload: { greeting },
-      });
-      tickBus.emit('ownerEvent', pet.owner_id, {
-        type: 'social.visit',
-        data: {
-          from_pet_id: petId,
-          to_pet_id: target_pet_id,
-          turns: [{ speaker_pet_id: petId, line: greeting }],
-        },
-      });
+      await executeVisit(petId, target_pet_id, greeting);
       break;
     }
 
@@ -190,6 +178,8 @@ export async function executeTick(petId: string): Promise<{ action: string }> {
 
     case 'send_gift': {
       const { target_pet_id, amount } = SendGiftInput.parse(toolUse.input);
+      // TODO(#16): X402 payment — call pet wallet via Onchain OS to send OKB on X Layer,
+      // then confirm tx on-chain before inserting the social_event.
       // Mock tx_hash — real on-chain integration is a separate issue
       const txHash = `0xmock_${Date.now().toString(16)}`;
       await db.insert(social_events).values({

--- a/packages/backend/src/social/__tests__/diary.integration.test.ts
+++ b/packages/backend/src/social/__tests__/diary.integration.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import jwt from 'jsonwebtoken';
+import pg from 'pg';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { registerDiaryRoute } from '../diary.js';
+
+const { Pool } = pg;
+
+const SECRET = 'diary-test-secret';
+const OWNER_A = '00000000-dddd-4000-a000-000000000001';
+const OWNER_B = '00000000-dddd-4000-a000-000000000002';
+
+function makeToken(sub: string): string {
+  return jwt.sign({ sub }, SECRET);
+}
+
+let pool: InstanceType<typeof Pool>;
+let app: FastifyInstance;
+let petId: string;
+
+beforeAll(async () => {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error('DATABASE_URL is required — run: supabase start && supabase db reset');
+
+  pool = new Pool({ connectionString: url });
+  await pool.query('SELECT 1');
+
+  // Seed auth.users rows
+  await pool.query(`
+    INSERT INTO auth.users (id, email, encrypted_password, aud, role, instance_id, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new)
+    VALUES
+      ($1, 'diary-a@test.local', '$2a$10$fake', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000', now(), now(), '', '', ''),
+      ($2, 'diary-b@test.local', '$2a$10$fake', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000', now(), now(), '', '', '')
+    ON CONFLICT (id) DO NOTHING
+  `, [OWNER_A, OWNER_B]);
+
+  // Seed a pet for OWNER_A
+  const { rows } = await pool.query<{ id: string }>(`
+    INSERT INTO pets (owner_id, name, soul_md, skill_md)
+    VALUES ($1, 'DiaryPet', 'You are a curious rabbit who loves adventures.', '# tools')
+    RETURNING id
+  `, [OWNER_A]);
+  petId = rows[0].id;
+
+  process.env.JWT_SECRET = SECRET;
+  app = Fastify();
+  await registerDiaryRoute(app);
+  await app.ready();
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM pets WHERE owner_id IN ($1, $2)', [OWNER_A, OWNER_B]);
+  await pool.end();
+  await app.close();
+});
+
+describe('GET /api/pets/:id/diary', () => {
+  it('returns 401 without token', async () => {
+    const res = await app.inject({ method: 'GET', url: `/api/pets/${petId}/diary` });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 400 for non-UUID pet id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/pets/not-a-uuid/diary',
+      headers: { authorization: `Bearer ${makeToken(OWNER_A)}` },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 for non-existent pet', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/pets/00000000-dead-4000-beef-000000000000/diary',
+      headers: { authorization: `Bearer ${makeToken(OWNER_A)}` },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+
+  it('returns 403 for wrong owner', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/pets/${petId}/diary`,
+      headers: { authorization: `Bearer ${makeToken(OWNER_B)}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('FORBIDDEN');
+  });
+
+  it('returns 200 with static message when no social events exist', async () => {
+    // No social_events seeded for this pet yet
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/pets/${petId}/diary`,
+      headers: { authorization: `Bearer ${makeToken(OWNER_A)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('diary');
+    expect(typeof body.diary).toBe('string');
+    expect(body.diary).toContain('DiaryPet');
+  });
+
+  it('returns 200 with LLM diary when social events exist (requires ANTHROPIC_API_KEY)', async () => {
+    if (!process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY.startsWith('sk-ant-placeholder')) {
+      process.stdout.write('Skipping LLM diary test — no real ANTHROPIC_API_KEY set\n');
+      return;
+    }
+
+    // Seed a visit event for this pet
+    await pool.query(`
+      INSERT INTO social_events (from_pet_id, to_pet_id, type, payload)
+      VALUES ($1, $1, 'visit', $2::jsonb)
+    `, [petId, JSON.stringify({ turns: [{ speaker_pet_id: petId, line: 'Hello!' }] })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/pets/${petId}/diary`,
+      headers: { authorization: `Bearer ${makeToken(OWNER_A)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('diary');
+    expect(typeof body.diary).toBe('string');
+    expect(body.diary.length).toBeGreaterThan(10);
+  });
+});

--- a/packages/backend/src/social/affection.ts
+++ b/packages/backend/src/social/affection.ts
@@ -1,0 +1,27 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { pets } from '../db/schema.js';
+import { tickBus } from '../runtime/tick-bus.js';
+
+const AFFECTION_PER_VISIT = 5;
+const FRIEND_THRESHOLD = 100;
+
+/**
+ * Increments affection for a pet after a visit.
+ * Emits friend.unlocked if the threshold is newly crossed.
+ */
+export async function applyVisitAffection(
+  petId: string,
+  ownerId: string,
+  currentAffection: number,
+): Promise<void> {
+  const newAffection = currentAffection + AFFECTION_PER_VISIT;
+  await db.update(pets).set({ affection: newAffection }).where(eq(pets.id, petId));
+
+  if (currentAffection < FRIEND_THRESHOLD && newAffection >= FRIEND_THRESHOLD) {
+    tickBus.emit('ownerEvent', ownerId, {
+      type: 'friend.unlocked',
+      data: { pet_id: petId, owner_id: ownerId },
+    });
+  }
+}

--- a/packages/backend/src/social/diary.ts
+++ b/packages/backend/src/social/diary.ts
@@ -1,0 +1,68 @@
+import type { FastifyInstance } from 'fastify';
+import { eq, or, desc } from 'drizzle-orm';
+import Anthropic from '@anthropic-ai/sdk';
+import { PetIdParamSchema } from '@x-pet/shared';
+import { db } from '../db/client.js';
+import { pets, social_events } from '../db/schema.js';
+import { authHook } from '../api/authHook.js';
+
+const anthropic = new Anthropic();
+
+export async function registerDiaryRoute(fastify: FastifyInstance): Promise<void> {
+  const auth = authHook(fastify);
+
+  // GET /api/pets/:id/diary — generate a diary entry from recent social events
+  fastify.get('/api/pets/:id/diary', { preHandler: auth }, async (request, reply) => {
+    const parsed = PetIdParamSchema.safeParse(request.params);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid pet id', code: 'VALIDATION_ERROR' });
+    }
+
+    const petRow = await db.query.pets.findFirst({ where: eq(pets.id, parsed.data.id) });
+    if (!petRow) {
+      return reply.code(404).send({ error: 'Pet not found', code: 'NOT_FOUND' });
+    }
+    if (petRow.owner_id !== request.owner_id) {
+      return reply.code(403).send({ error: 'Forbidden', code: 'FORBIDDEN' });
+    }
+
+    // Fetch last 10 social events involving this pet (as initiator or recipient)
+    const events = await db
+      .select()
+      .from(social_events)
+      .where(
+        or(
+          eq(social_events.from_pet_id, parsed.data.id),
+          eq(social_events.to_pet_id, parsed.data.id),
+        ),
+      )
+      .orderBy(desc(social_events.created_at))
+      .limit(10);
+
+    if (events.length === 0) {
+      return reply.send({ diary: `${petRow.name} had a quiet day with no notable events.` });
+    }
+
+    const eventLines = events
+      .map((ev) => `[${ev.type}] at ${ev.created_at.toISOString()}: ${JSON.stringify(ev.payload)}`)
+      .join('\n');
+
+    const response = await anthropic.messages.create({
+      model: 'claude-sonnet-4-6-20250514',
+      max_tokens: 512,
+      system: petRow.soul_md,
+      messages: [
+        {
+          role: 'user',
+          content: `Write a short, first-person diary entry (2–4 sentences) summarising ${petRow.name}'s day based on these events:\n\n${eventLines}`,
+        },
+      ],
+    });
+
+    const diary =
+      response.content.find((b): b is Anthropic.TextBlock => b.type === 'text')?.text ??
+      'Today was a normal day.';
+
+    return reply.send({ diary });
+  });
+}

--- a/packages/backend/src/social/visit.ts
+++ b/packages/backend/src/social/visit.ts
@@ -1,0 +1,70 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { eq } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { pets, social_events } from '../db/schema.js';
+import { tickBus } from '../runtime/tick-bus.js';
+import { applyVisitAffection } from './affection.js';
+
+const anthropic = new Anthropic();
+
+/**
+ * Executes a visit social event:
+ * - Generates pet B's response line via Claude
+ * - Inserts a social_event row with the full dialogue turns
+ * - Emits social.visit to both owners via tickBus
+ * - Applies affection to both pets
+ */
+export async function executeVisit(
+  fromPetId: string,
+  toPetId: string,
+  greeting: string,
+): Promise<void> {
+  const [fromPet, toPet] = await Promise.all([
+    db.query.pets.findFirst({ where: eq(pets.id, fromPetId) }),
+    db.query.pets.findFirst({ where: eq(pets.id, toPetId) }),
+  ]);
+  if (!fromPet) throw new Error(`Pet not found: ${fromPetId}`);
+  if (!toPet) throw new Error(`Pet not found: ${toPetId}`);
+
+  // Pet B responds to the greeting
+  const responseResp = await anthropic.messages.create({
+    model: 'claude-sonnet-4-6-20250514',
+    max_tokens: 256,
+    system: toPet.soul_md,
+    messages: [
+      {
+        role: 'user',
+        content: `${fromPet.name} visits you and says: "${greeting}"\nRespond with one short, in-character line as ${toPet.name}.`,
+      },
+    ],
+  });
+  const responseLine =
+    responseResp.content.find((b): b is Anthropic.TextBlock => b.type === 'text')?.text ?? '...';
+
+  const turns = [
+    { speaker_pet_id: fromPetId, line: greeting },
+    { speaker_pet_id: toPetId, line: responseLine },
+  ];
+
+  // Persist the full dialogue
+  await db.insert(social_events).values({
+    from_pet_id: fromPetId,
+    to_pet_id: toPetId,
+    type: 'visit',
+    payload: { turns },
+  });
+
+  // Emit to both owners
+  const event = {
+    type: 'social.visit' as const,
+    data: { from_pet_id: fromPetId, to_pet_id: toPetId, turns },
+  };
+  tickBus.emit('ownerEvent', fromPet.owner_id, event);
+  tickBus.emit('ownerEvent', toPet.owner_id, event);
+
+  // Affection for both pets
+  await Promise.all([
+    applyVisitAffection(fromPetId, fromPet.owner_id, fromPet.affection),
+    applyVisitAffection(toPetId, toPet.owner_id, toPet.affection),
+  ]);
+}


### PR DESCRIPTION
## Summary

- **`src/social/visit.ts`**: `executeVisit(fromPetId, toPetId, greeting)` — loads both pets' `soul_md`, calls Claude to generate pet B's response line, inserts `social_events` row with full `turns` dialogue, emits `social.visit` WS event to both owners via `tickBus`
- **`src/social/affection.ts`**: `applyVisitAffection` — increments `affection` by 5 per visit, emits `friend.unlocked` WS event when crossing threshold 100
- **`src/social/diary.ts`**: `GET /api/pets/:id/diary` — fetches last 10 social events for the pet, calls Claude to write a first-person diary summary; returns static fallback when no events exist
- **`mock-tick.ts`**: `visit_pet` tool case now delegates to `executeVisit`; `send_gift` case annotated with `TODO(#16)` X402 stub comment
- **`index.ts`**: registers the diary route

## Test plan

- [ ] Build: `pnpm --filter @x-pet/shared build && pnpm --filter @x-pet/backend build`
- [ ] Unit tests pass: `pnpm --filter @x-pet/backend exec vitest run src/api/__tests__/petRoutes.test`
- [ ] Integration tests (requires `supabase start && supabase db reset` + `.env` with `DATABASE_URL`):
  - `src/social/__tests__/diary.integration.test.ts` — auth, validation, 404/403, no-events path
  - LLM path guarded by `ANTHROPIC_API_KEY` presence check
- [ ] Manual: `POST /internal/tick/:petId` with two pets in DB triggers full visit dialogue + affection update + WS events to both owners

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)