### PR TITLE
feat(onchain): ethers.js HD wallet integration — createWallet, transfer, getBalance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ DATABASE_MIGRATION_URL=postgresql://user:password@host:5432/dbname
 ANTHROPIC_API_KEY=sk-ant-...
 ONCHAIN_OS_API_KEY=your-onchain-os-api-key
 ONCHAIN_OS_API_URL=https://www.okx.com/priapi/v1/onchain-os
-X_LAYER_RPC_URL=https://rpc.xlayer.tech
+X_LAYER_RPC_URL=https://testrpc.xlayer.tech
+# 32-byte AES-256-GCM key for encrypting pet wallet private keys (hex, 64 chars)
+WALLET_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
 X402_FACILITATOR_URL=https://facilitator.x402.org
 PORT=3000
 # Supabase — used to verify JWTs via supabase.auth.getUser() on the server

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -2,3 +2,5 @@ JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres
 BACKEND_URL=http://localhost:3001
+# 32-byte AES-256-GCM key for encrypting pet wallet private keys (hex, 64 chars)
+WALLET_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000

--- a/packages/backend/drizzle/0004_wallet_key.sql
+++ b/packages/backend/drizzle/0004_wallet_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pets" ADD COLUMN "wallet_encrypted_key" text;

--- a/packages/backend/drizzle/meta/_journal.json
+++ b/packages/backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774173753825,
       "tag": "0003_happy_gamma_corps",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1774200000000,
+      "tag": "0004_wallet_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/api/__tests__/helpers.ts
+++ b/packages/backend/src/api/__tests__/helpers.ts
@@ -19,6 +19,7 @@ export type PetRow = {
   soul_md: string;
   skill_md: string;
   wallet_address: string | null;
+  wallet_encrypted_key: string | null;
   hunger: number;
   mood: number;
   affection: number;
@@ -53,6 +54,7 @@ export function seedPet(overrides: Partial<PetRow> & { id: string; owner_id: str
     soul_md: '#',
     skill_md: '#',
     wallet_address: null,
+    wallet_encrypted_key: null,
     hunger: 100,
     mood: 100,
     affection: 0,
@@ -104,6 +106,7 @@ vi.mock('../../db/client.js', () => {
               soul_md: vals.soul_md ?? '',
               skill_md: vals.skill_md ?? '',
               wallet_address: vals.wallet_address ?? null,
+              wallet_encrypted_key: vals.wallet_encrypted_key ?? null,
               hunger: vals.hunger ?? 100,
               mood: vals.mood ?? 100,
               affection: vals.affection ?? 0,
@@ -149,11 +152,13 @@ vi.mock('drizzle-orm', () => ({
 
 export async function buildApp(): Promise<FastifyInstance> {
   process.env.JWT_SECRET = SECRET;
+  process.env.WALLET_ENCRYPTION_KEY = '0'.repeat(64);
   const { registerPetRoutes } = await import('../petRoutes.js');
   const app = Fastify();
   await registerPetRoutes(app, {
     generateSoulMd: () => '# SOUL',
     generateSkillMd: () => '# SKILL',
+    createWallet: (petId: string) => ({ address: `0xwallet-${petId}`, encryptedKey: 'test-encrypted' }),
   });
   return app;
 }

--- a/packages/backend/src/api/__tests__/petRoutes.integration.test.ts
+++ b/packages/backend/src/api/__tests__/petRoutes.integration.test.ts
@@ -37,10 +37,12 @@ beforeAll(async () => {
   await pool.query('DELETE FROM pets WHERE owner_id IN ($1, $2)', [OWNER_A, OWNER_B]);
 
   process.env.JWT_SECRET = SECRET;
+  process.env.WALLET_ENCRYPTION_KEY = '0'.repeat(64);
   app = Fastify();
   await registerPetRoutes(app, {
     generateSoulMd: () => '# SOUL smoke',
     generateSkillMd: () => '# SKILL smoke',
+    createWallet: (petId: string) => ({ address: `0xtest-${petId.slice(0, 8)}`, encryptedKey: 'smoke-encrypted' }),
   });
 });
 
@@ -116,6 +118,15 @@ describe('pet CRUD integration', () => {
     expect(rows[0].owner_id).toBe(OWNER_A);
     expect(rows[0].soul_md).toBe('# SOUL smoke');
     expect(rows[0].skill_md).toBe('# SKILL smoke');
+  });
+
+  it('DB side effect: wallet_address and wallet_encrypted_key are persisted after POST', async () => {
+    const { rows } = await pool.query('SELECT wallet_address, wallet_encrypted_key FROM pets WHERE id = $1', [createdPetId]);
+    expect(rows).toHaveLength(1);
+    expect(typeof rows[0].wallet_address).toBe('string');
+    expect(rows[0].wallet_address.length).toBeGreaterThan(0);
+    expect(typeof rows[0].wallet_encrypted_key).toBe('string');
+    expect(rows[0].wallet_encrypted_key.length).toBeGreaterThan(0);
   });
 
   it('GET /api/pets/:id returns 200 with owner_id for owner', async () => {

--- a/packages/backend/src/api/petRoutes.ts
+++ b/packages/backend/src/api/petRoutes.ts
@@ -4,13 +4,15 @@ import { PetCreateSchema, PetIdParamSchema } from '@x-pet/shared';
 import { db } from '../db/client.js';
 import { pets } from '../db/schema.js';
 import { authHook } from './authHook.js';
+import { createWallet } from '../onchain/wallet.js';
 
 export type PetRouteDeps = {
   generateSoulMd: (input: { name: string; mood: number; soul_prompt: string }) => string;
   generateSkillMd: (input: { id: string; backendUrl: string }) => string;
+  createWallet: (petId: string) => { address: string; encryptedKey: string };
 };
 
-// TODO(#39): wallet_address returns '' until Onchain OS container lifecycle lands
+// Wallet is created synchronously on pet creation via ethers.js HD derivation (docs/risks.md R3)
 
 /** POST /api/pets (201) and GET /api/pets response shape — no owner_id per contract */
 function toPetSummary(row: typeof pets.$inferSelect) {
@@ -70,11 +72,12 @@ export async function registerPetRoutes(
       })
       .returning();
 
-    // Generate skill_md with the real pet id
+    // Generate skill_md with the real pet id, and derive deterministic wallet
     const skill_md = deps.generateSkillMd({ id: row.id, backendUrl });
+    const walletInfo = deps.createWallet(row.id);
     const [updated] = await db
       .update(pets)
-      .set({ skill_md })
+      .set({ skill_md, wallet_address: walletInfo.address, wallet_encrypted_key: walletInfo.encryptedKey })
       .where(eq(pets.id, row.id))
       .returning();
 

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -27,8 +27,10 @@ export const pets = pgTable('pets', {
   name: text('name').notNull(),
   soul_md: text('soul_md').notNull(),
   skill_md: text('skill_md').notNull(),
-  // Null until Onchain OS creates the wallet asynchronously after container start
+  // Null until wallet is created on pet creation
   wallet_address: text('wallet_address'),
+  // AES-256-GCM encrypted private key — format: iv:tag:ciphertext (all hex)
+  wallet_encrypted_key: text('wallet_encrypted_key'),
   hunger: integer('hunger').notNull().default(100),
   mood: integer('mood').notNull().default(100),
   affection: integer('affection').notNull().default(0),

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -9,6 +9,7 @@ import { registerChatRoute } from './api/chatRoute.js';
 import { generateSoulMd } from './runtime/soul-generator.js';
 import { generateSkillMd } from './runtime/skill-generator.js';
 import { tickBus } from './runtime/tick-bus.js';
+import { createWallet } from './onchain/wallet.js';
 
 const fastify = Fastify({ logger: true });
 
@@ -16,7 +17,7 @@ await fastify.register(fastifyCors, { origin: true });
 await fastify.register(fastifyWebsocket);
 await registerWsRoute(fastify);
 await registerTickRoute(fastify);
-await registerPetRoutes(fastify, { generateSoulMd, generateSkillMd });
+await registerPetRoutes(fastify, { generateSoulMd, generateSkillMd, createWallet });
 await registerChatRoute(fastify, {
   emitOwnerEvent: (ownerId, event) => tickBus.emit('ownerEvent', ownerId, event),
 });

--- a/packages/backend/src/onchain/__tests__/wallet.test.ts
+++ b/packages/backend/src/onchain/__tests__/wallet.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ethers } from 'ethers';
+import { createWallet, encryptPrivateKey, decryptPrivateKey } from '../wallet.js';
+
+const TEST_KEY = '0'.repeat(64); // 32 zero bytes as hex
+
+beforeEach(() => {
+  process.env.WALLET_ENCRYPTION_KEY = TEST_KEY;
+});
+
+describe('encryptPrivateKey / decryptPrivateKey', () => {
+  it('round-trips a private key', () => {
+    const privateKey = '0x' + 'ab'.repeat(32);
+    const encrypted = encryptPrivateKey(privateKey);
+    expect(encrypted.split(':').length).toBe(3);
+    expect(decryptPrivateKey(encrypted)).toBe(privateKey);
+  });
+
+  it('produces different ciphertexts for same key (random IV)', () => {
+    const privateKey = '0x' + 'cd'.repeat(32);
+    const a = encryptPrivateKey(privateKey);
+    const b = encryptPrivateKey(privateKey);
+    expect(a).not.toBe(b);
+    expect(decryptPrivateKey(a)).toBe(privateKey);
+    expect(decryptPrivateKey(b)).toBe(privateKey);
+  });
+});
+
+describe('createWallet', () => {
+  it('returns a valid Ethereum address', () => {
+    const { address } = createWallet('pet-id-abc');
+    expect(ethers.isAddress(address)).toBe(true);
+  });
+
+  it('is deterministic — same petId yields same address', () => {
+    const a = createWallet('pet-id-abc');
+    const b = createWallet('pet-id-abc');
+    expect(a.address).toBe(b.address);
+  });
+
+  it('different petIds yield different addresses', () => {
+    const a = createWallet('pet-id-001');
+    const b = createWallet('pet-id-002');
+    expect(a.address).not.toBe(b.address);
+  });
+
+  it('encryptedKey can be decrypted to the same wallet private key', () => {
+    const { address, encryptedKey } = createWallet('pet-id-xyz');
+    const recoveredKey = decryptPrivateKey(encryptedKey);
+    const recovered = new ethers.Wallet(recoveredKey);
+    expect(recovered.address).toBe(address);
+  });
+});

--- a/packages/backend/src/onchain/wallet.ts
+++ b/packages/backend/src/onchain/wallet.ts
@@ -1,0 +1,138 @@
+/**
+ * Onchain wallet module — ethers.js HD wallet fallback (docs/risks.md R3)
+ *
+ * Derives a deterministic Ethereum wallet for each pet using HMAC-SHA256 of
+ * petId with WALLET_ENCRYPTION_KEY as the HMAC key.  Private keys are stored
+ * AES-256-GCM encrypted in pets.wallet_encrypted_key.
+ */
+
+import crypto from 'node:crypto';
+import { ethers } from 'ethers';
+
+const X_LAYER_TESTNET_RPC = process.env.X_LAYER_RPC_URL ?? 'https://testrpc.xlayer.tech';
+
+// Minimal ERC-20 ABI — only the methods we need
+const ERC20_ABI = [
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function balanceOf(address owner) view returns (uint256)',
+  'function decimals() view returns (uint8)',
+];
+
+// ── Encryption helpers ────────────────────────────────────────────────────────
+
+function getEncryptionKey(): Buffer {
+  const raw = process.env.WALLET_ENCRYPTION_KEY;
+  if (!raw) throw new Error('WALLET_ENCRYPTION_KEY environment variable is required');
+  // Accept hex (64 chars) or base64 (44 chars) 32-byte key
+  if (/^[0-9a-fA-F]{64}$/.test(raw)) return Buffer.from(raw, 'hex');
+  const buf = Buffer.from(raw, 'base64');
+  if (buf.length !== 32) throw new Error('WALLET_ENCRYPTION_KEY must be 32 bytes (hex or base64)');
+  return buf;
+}
+
+export function encryptPrivateKey(privateKey: string): string {
+  const key = getEncryptionKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  let ct = cipher.update(privateKey, 'utf8', 'hex');
+  ct += cipher.final('hex');
+  const tag = cipher.getAuthTag().toString('hex');
+  // Format: iv:tag:ciphertext  (all hex)
+  return `${iv.toString('hex')}:${tag}:${ct}`;
+}
+
+export function decryptPrivateKey(encrypted: string): string {
+  const key = getEncryptionKey();
+  const parts = encrypted.split(':');
+  if (parts.length !== 3) throw new Error('Invalid encrypted key format');
+  const [ivHex, tagHex, ct] = parts;
+  const iv = Buffer.from(ivHex, 'hex');
+  const tag = Buffer.from(tagHex, 'hex');
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  let plain = decipher.update(ct, 'hex', 'utf8');
+  plain += decipher.final('utf8');
+  return plain;
+}
+
+// ── Deterministic key derivation ──────────────────────────────────────────────
+
+function derivePrivateKey(petId: string): string {
+  const key = getEncryptionKey();
+  const hmac = crypto.createHmac('sha256', key);
+  hmac.update(`x-pet-wallet:${petId}`);
+  return '0x' + hmac.digest('hex');
+}
+
+// ── Public interface ──────────────────────────────────────────────────────────
+
+export type WalletInfo = {
+  address: string;
+  encryptedKey: string;
+};
+
+/**
+ * Derive a deterministic wallet for a pet and return its address plus
+ * the AES-256-GCM encrypted private key for storage.
+ */
+export function createWallet(petId: string): WalletInfo {
+  const privateKey = derivePrivateKey(petId);
+  const wallet = new ethers.Wallet(privateKey);
+  const encryptedKey = encryptPrivateKey(privateKey);
+  return { address: wallet.address, encryptedKey };
+}
+
+/**
+ * Transfer native token (OKB) or ERC-20 token from one pet wallet to another.
+ * `encryptedKey` is the stored encrypted private key for the `from` address.
+ * Returns the transaction hash.
+ */
+export async function transfer(
+  encryptedKey: string,
+  to: string,
+  token: string,
+  amount: string,
+): Promise<string> {
+  const provider = new ethers.JsonRpcProvider(X_LAYER_TESTNET_RPC);
+  const privateKey = decryptPrivateKey(encryptedKey);
+  const signer = new ethers.Wallet(privateKey, provider);
+
+  const isNative = token === 'OKB' || token === 'ETH';
+
+  if (isNative) {
+    const tx = await signer.sendTransaction({
+      to,
+      value: ethers.parseEther(amount),
+    });
+    return tx.hash;
+  }
+
+  // ERC-20: `token` is the contract address
+  const contract = new ethers.Contract(token, ERC20_ABI, signer);
+  const decimals: number = await contract.decimals();
+  const parsed = ethers.parseUnits(amount, decimals);
+  const tx = await contract.transfer(to, parsed);
+  return tx.hash;
+}
+
+/**
+ * Get the balance of an address for a given token.
+ * Returns balance as a decimal string (e.g. "1.5").
+ */
+export async function getBalance(address: string, token: string): Promise<string> {
+  const provider = new ethers.JsonRpcProvider(X_LAYER_TESTNET_RPC);
+
+  const isNative = token === 'OKB' || token === 'ETH';
+
+  if (isNative) {
+    const balance = await provider.getBalance(address);
+    return ethers.formatEther(balance);
+  }
+
+  const contract = new ethers.Contract(token, ERC20_ABI, provider);
+  const [balance, decimals]: [bigint, number] = await Promise.all([
+    contract.balanceOf(address),
+    contract.decimals(),
+  ]);
+  return ethers.formatUnits(balance, decimals);
+}


### PR DESCRIPTION
## Summary

- **`src/onchain/wallet.ts`**: deterministic HD wallet derivation from `petId` via HMAC-SHA256 (using `WALLET_ENCRYPTION_KEY` as HMAC key); AES-256-GCM encryption of private keys; `transfer()` and `getBalance()` against X Layer testnet RPC
- **Schema + migration**: adds `wallet_encrypted_key text` column to `pets` table (`drizzle/0004_wallet_key.sql`)
- **`POST /api/pets`**: wires `createWallet(petId)` so every new pet immediately gets a wallet address and encrypted key persisted to DB
- **`WALLET_ENCRYPTION_KEY`** added to both `.env.example` files

## Tests

- Unit tests (`src/onchain/__tests__/wallet.test.ts`): encrypt/decrypt round-trip, random IVs, determinism, address recovery — all pass without a DB
- Integration test: asserts `wallet_address` and `wallet_encrypted_key` are non-empty strings in DB after `POST /api/pets`

## Notes

Uses the ethers.js fallback path per docs/risks.md R3 (no OKX Onchain OS API key available). X Layer testnet RPC: `https://testrpc.xlayer.tech`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)