### PR TITLE
fix: use host.docker.internal as BACKEND_URL default for OrbStack

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,6 +57,7 @@ For the **backend** service, add all variables from `.env.example`:
 | `ONCHAIN_OS_API_URL` | OKX Onchain OS API base URL |
 | `X_LAYER_RPC_URL` | X Layer (zkEVM L2) RPC endpoint |
 | `X402_FACILITATOR_URL` | X402 payment facilitator URL |
+| `BACKEND_URL` | Public Railway backend URL — baked into each pet's SKILL.md at creation so OpenClaw containers on Hetzner can curl `/internal/tools/*` (e.g. `https://backend.up.railway.app`) |
 | `PORT` | HTTP port, defaults to `3000` (Railway sets this automatically) |
 | `JWT_SECRET` | Secret for signing JWT tokens |
 | `TELEGRAM_BOT_TOKEN` | (Optional) Telegram bot token |

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,7 +1,10 @@
 JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres
-BACKEND_URL=http://localhost:3001
+# URL that OpenClaw containers use to curl back to the backend (baked into SKILL.md at pet creation).
+# Local dev (OrbStack): host.docker.internal reaches the macOS host from inside Docker containers.
+# Prod (Railway): set to the public Railway backend URL, e.g. https://backend.up.railway.app
+BACKEND_URL=http://host.docker.internal:3001
 # OKX Onchain OS credentials — forwarded to per-pet OpenClaw containers so the
 # onchainos CLI can authenticate. Apply at https://www.okx.com/web3/build/dev-portal
 OKX_API_KEY=your-okx-api-key-here


### PR DESCRIPTION
## Summary
- `.env.example`: change `BACKEND_URL` default from `localhost:3001` to `host.docker.internal:3001` with explanation comment
- `docs/deploy.md`: add `BACKEND_URL` row to Railway env var table

## Why
OpenClaw containers execute curl commands with `BACKEND_URL` baked into SKILL.md at pet creation. `localhost` inside a container resolves to the container's own loopback — the request never reaches the macOS host backend. OrbStack officially supports `host.docker.internal` for container→macOS-host networking (no `--add-host` flag needed).

Prod path: containers on Hetzner curl the public Railway `BACKEND_URL` over the internet, protected by `Authorization: Bearer <OPENCLAW_WEBHOOK_TOKEN>`.

closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)