### PR TITLE
feat(ui): replace emoji icons with inline SVG in HUD

### DIFF
--- a/packages/frontend/src/ui/DiaryPanel.ts
+++ b/packages/frontend/src/ui/DiaryPanel.ts
@@ -1,3 +1,5 @@
+import { Icons } from './icons';
+
 /** Centered modal overlay showing the pet's diary from GET /api/pets/demo/diary. */
 export class DiaryPanel {
   readonly el: HTMLDivElement;
@@ -18,7 +20,7 @@ export class DiaryPanel {
 
     const title = document.createElement('span');
     title.className = 'diary-title';
-    title.textContent = '📖 My Diary';
+    title.append(Icons.bookOpen(12), ' My Diary');
 
     const closeBtn = document.createElement('button');
     closeBtn.className = 'diary-close-btn';
@@ -53,7 +55,10 @@ export class DiaryPanel {
         this.body.textContent = data.summary ?? 'No diary entry.';
       })
       .catch(() => {
-        this.body.innerHTML = '<span class="diary-empty">📭 No entries yet — come back after your pet has had a big day!</span>';
+        const empty = document.createElement('span');
+        empty.className = 'diary-empty';
+        empty.append(Icons.inbox(13), ' No entries yet — come back after your pet has had a big day!');
+        this.body.replaceChildren(empty);
       });
   }
 

--- a/packages/frontend/src/ui/HudBar.ts
+++ b/packages/frontend/src/ui/HudBar.ts
@@ -1,5 +1,6 @@
 import { DiaryPanel } from './DiaryPanel';
 import { FriendsPanel } from './FriendsPanel';
+import { Icons } from './icons';
 
 interface StatSlot {
   fill: HTMLDivElement;
@@ -7,9 +8,9 @@ interface StatSlot {
 }
 
 const STAT_DEFS = [
-  { key: 'hunger',    icon: '🍎', label: 'Hunger' },
-  { key: 'mood',      icon: '😊', label: 'Mood' },
-  { key: 'affection', icon: '💗', label: 'Love' },
+  { key: 'hunger',    icon: Icons.apple,  label: 'Hunger' },
+  { key: 'mood',      icon: Icons.smile,  label: 'Mood' },
+  { key: 'affection', icon: Icons.heart,  label: 'Love' },
 ];
 
 /**
@@ -41,8 +42,8 @@ export class HudBar {
 
       const label = document.createElement('span');
       label.className = 'hud-stat-label';
-      label.textContent = `${def.icon}`;
       label.title = def.label;
+      label.appendChild(def.icon());
 
       const track = document.createElement('div');
       track.className = 'stat-track';
@@ -68,7 +69,7 @@ export class HudBar {
 
     const diaryBtn = document.createElement('button');
     diaryBtn.className = 'hud-btn hud-diary-btn';
-    diaryBtn.textContent = '📖 Diary';
+    diaryBtn.append(Icons.bookOpen(), ' Diary');
     diaryBtn.addEventListener('click', () => {
       this.friendsPanel.close();
       if (this.diaryPanel.isOpen()) {
@@ -80,7 +81,7 @@ export class HudBar {
 
     const friendsBadge = document.createElement('button');
     friendsBadge.className = 'hud-btn hud-friends-btn';
-    friendsBadge.textContent = '👥 Friends';
+    friendsBadge.append(Icons.users(), ' Friends');
     friendsBadge.addEventListener('click', () => {
       this.diaryPanel.close();
       this.friendsPanel.toggle();
@@ -92,14 +93,13 @@ export class HudBar {
     const walletSection = document.createElement('div');
     walletSection.className = 'hud-wallet';
 
-    const walletIcon = document.createElement('span');
-    walletIcon.textContent = '💰';
+    walletSection.appendChild(Icons.wallet());
 
     const walletBalance = document.createElement('span');
     walletBalance.className = 'hud-wallet-balance';
     walletBalance.textContent = '0.05 OKB';
 
-    walletSection.append(walletIcon, walletBalance);
+    walletSection.appendChild(walletBalance);
 
     this.el.append(statsSection, centerSection, walletSection);
   }

--- a/packages/frontend/src/ui/StatBars.ts
+++ b/packages/frontend/src/ui/StatBars.ts
@@ -1,3 +1,5 @@
+import { Icons } from './icons';
+
 interface Stat {
   key: string;
   label: string;
@@ -15,10 +17,10 @@ export class StatBars {
     this.el.id = 'stat-bars';
     this.el.classList.add('ui-panel');
 
-    const defs: { key: string; label: string; icon: string }[] = [
-      { key: 'hunger', label: 'Hunger', icon: '🍎' },
-      { key: 'mood', label: 'Mood', icon: '😊' },
-      { key: 'affection', label: 'Love', icon: '💗' },
+    const defs: { key: string; label: string; icon: () => SVGSVGElement }[] = [
+      { key: 'hunger',    label: 'Hunger', icon: Icons.apple },
+      { key: 'mood',      label: 'Mood',   icon: Icons.smile },
+      { key: 'affection', label: 'Love',   icon: Icons.heart },
     ];
 
     this.stats = defs.map((def) => {
@@ -27,7 +29,7 @@ export class StatBars {
 
       const label = document.createElement('span');
       label.className = 'stat-label';
-      label.textContent = `${def.icon} ${def.label}`;
+      label.append(def.icon(), ` ${def.label}`);
 
       const track = document.createElement('div');
       track.className = 'stat-track';

--- a/packages/frontend/src/ui/Toasts.ts
+++ b/packages/frontend/src/ui/Toasts.ts
@@ -1,3 +1,5 @@
+import { Icons } from './icons';
+
 const DISMISS_MS = 4000;
 const ANIM_OUT_MS = 300;
 
@@ -28,25 +30,26 @@ export class Toasts {
   }
 
   gift(from: string, to: string, amount: string, token: string, txHash?: string): void {
-    if (!txHash) {
-      this.show(`🎁 ${from} sent ${amount} ${token} to ${to}`, 'gift');
-      return;
-    }
-
     const frag = document.createDocumentFragment();
-    frag.appendChild(document.createTextNode(`🎁 ${from} sent ${amount} ${token} to ${to} `));
-    const link = document.createElement('a');
-    link.href = `https://www.okx.com/explorer/xlayer/tx/${txHash}`;
-    link.target = '_blank';
-    link.rel = 'noopener noreferrer';
-    link.textContent = `${txHash.slice(0, 10)}…`;
-    link.style.color = 'inherit';
-    frag.appendChild(link);
+    frag.append(Icons.gift(13), ` ${from} sent ${amount} ${token} to ${to}`);
+
+    if (txHash) {
+      frag.appendChild(document.createTextNode(' '));
+      const link = document.createElement('a');
+      link.href = `https://www.okx.com/explorer/xlayer/tx/${txHash}`;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = `${txHash.slice(0, 10)}…`;
+      link.style.color = 'inherit';
+      frag.appendChild(link);
+    }
 
     this.show(frag, 'gift');
   }
 
   friendUnlocked(petId: string): void {
-    this.show(`💛 You and ${petId} are now friends!`, 'friend');
+    const frag = document.createDocumentFragment();
+    frag.append(Icons.heart(13), ` You and ${petId} are now friends!`);
+    this.show(frag, 'friend');
   }
 }

--- a/packages/frontend/src/ui/icons.ts
+++ b/packages/frontend/src/ui/icons.ts
@@ -1,0 +1,62 @@
+/** Lucide-compatible inline SVG icons (MIT). No runtime dependency. */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function makeSvg(pathContent: string, size = 14): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('width', String(size));
+  svg.setAttribute('height', String(size));
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.classList.add('ui-icon');
+  svg.innerHTML = pathContent;
+  return svg;
+}
+
+export const Icons = {
+  apple: (size?: number) =>
+    makeSvg(
+      `<path d="M12 20.94c1.5 0 2.75 1.06 4 1.06 3 0 6-8 6-12.22A4.91 4.91 0 0 0 17 5c-2.22 0-4 1.44-5 2-1-.56-2.78-2-5-2a4.9 4.9 0 0 0-5 4.78C2 14 5 22 8 22c1.25 0 2.5-1.06 4-1.06z"/><path d="M10 2c1 .5 2 2 2 5"/>`,
+      size,
+    ),
+  smile: (size?: number) =>
+    makeSvg(
+      `<circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/>`,
+      size,
+    ),
+  heart: (size?: number) =>
+    makeSvg(
+      `<path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"/>`,
+      size,
+    ),
+  bookOpen: (size?: number) =>
+    makeSvg(
+      `<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>`,
+      size,
+    ),
+  users: (size?: number) =>
+    makeSvg(
+      `<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>`,
+      size,
+    ),
+  wallet: (size?: number) =>
+    makeSvg(
+      `<path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/>`,
+      size,
+    ),
+  gift: (size?: number) =>
+    makeSvg(
+      `<polyline points="20 12 20 22 4 22 4 12"/><rect width="20" height="5" x="2" y="7"/><line x1="12" x2="12" y1="22" y2="7"/><path d="M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7z"/><path d="M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z"/>`,
+      size,
+    ),
+  inbox: (size?: number) =>
+    makeSvg(
+      `<polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>`,
+      size,
+    ),
+} as const;

--- a/packages/frontend/src/ui/styles.css
+++ b/packages/frontend/src/ui/styles.css
@@ -21,6 +21,13 @@
   --ui-font-body: 'Inter', system-ui, sans-serif;
 }
 
+/* ── SVG icon alignment ───────────────────────────────────────────── */
+.ui-icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
 /* ── Shared panel styling ─────────────────────────────────────────── */
 .ui-panel {
   background: var(--ui-panel-bg);


### PR DESCRIPTION
## Summary
- Adds `packages/frontend/src/ui/icons.ts` — a zero-dependency helper that generates Lucide-compatible SVG elements from inline path strings (MIT licensed)
- Replaces all emoji icons in `HudBar`, `StatBars`, `DiaryPanel`, and `Toasts` with consistent stroke-based SVG icons
- Adds `.ui-icon` CSS rule in `styles.css` for proper vertical alignment

## Icons replaced
| Emoji | SVG icon | Location |
|-------|----------|----------|
| 🍎 | apple | Hunger stat bar |
| 😊 | smile | Mood stat bar |
| 💗 | heart | Affection stat bar |
| 📖 | book-open | Diary button + panel title |
| 👥 | users | Friends button |
| 💰 | wallet | Wallet section |
| 🎁 | gift | Gift toast |
| 💛 | heart | Friend-unlocked toast |
| 📭 | inbox | Diary empty state |

## Test plan
- [ ] Load the frontend dev server and verify no emoji visible in HUD
- [ ] Check stat bars show SVG icons for hunger/mood/affection
- [ ] Open diary panel and verify book-open icon in title
- [ ] Verify gift and friend toasts render with SVG icons

closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)