### PR TITLE
fix(gift): emit social.gift to both sender/receiver, update toast copy

### DIFF
--- a/packages/backend/src/api/openclawRoutes.ts
+++ b/packages/backend/src/api/openclawRoutes.ts
@@ -74,7 +74,7 @@ export async function registerOpenclawRoutes(
         await executeVisit(petId, event.target_pet_id, event.greeting);
         break;
 
-      case 'gift':
+      case 'gift': {
         // TODO(#16): X402 payment — call pet wallet via Onchain OS to send OKB on X Layer
         await db.insert(social_events).values({
           from_pet_id: petId,
@@ -82,11 +82,17 @@ export async function registerOpenclawRoutes(
           type: 'gift',
           payload: { amount: event.amount, token: 'OKB', tx_hash: event.tx_hash ?? '' },
         });
-        deps.emitOwnerEvent(pet.owner_id, {
+        const giftEventHeartbeat: WsEvent = {
           type: 'social.gift',
           data: { from_pet_id: petId, to_pet_id: event.target_pet_id, token: 'OKB', amount: event.amount, tx_hash: event.tx_hash ?? '' },
-        });
+        };
+        deps.emitOwnerEvent(pet.owner_id, giftEventHeartbeat);
+        const receiverPetHeartbeat = await db.query.pets.findFirst({ where: eq(pets.id, event.target_pet_id) });
+        if (receiverPetHeartbeat && receiverPetHeartbeat.owner_id !== pet.owner_id) {
+          deps.emitOwnerEvent(receiverPetHeartbeat.owner_id, giftEventHeartbeat);
+        }
         break;
+      }
 
       case 'rest': {
         const newHunger = Math.min(100, pet.hunger + 10);
@@ -257,10 +263,14 @@ export async function registerOpenclawRoutes(
       x_layer_confirmed: true,
     });
 
-    deps.emitOwnerEvent(pet.owner_id, {
+    const giftEventSendGift: WsEvent = {
       type: 'social.gift',
       data: { from_pet_id: pet_id, to_pet_id: target_pet_id, token, amount, tx_hash: txHash },
-    });
+    };
+    deps.emitOwnerEvent(pet.owner_id, giftEventSendGift);
+    if (targetPet.owner_id !== pet.owner_id) {
+      deps.emitOwnerEvent(targetPet.owner_id, giftEventSendGift);
+    }
 
     return reply.send({ ok: true, tx_hash: txHash });
   });

--- a/packages/backend/src/runtime/mock-tick.ts
+++ b/packages/backend/src/runtime/mock-tick.ts
@@ -89,10 +89,14 @@ export async function executeTick(petId: string): Promise<{ action: string }> {
           type: 'gift',
           payload: { amount: '0.001', token: 'OKB', tx_hash: txHash },
         });
-        tickBus.emit('ownerEvent', pet.owner_id, {
-          type: 'social.gift',
+        const demoGiftEvent = {
+          type: 'social.gift' as const,
           data: { from_pet_id: petId, to_pet_id: targetId, token: 'OKB', amount: '0.001', tx_hash: txHash },
-        });
+        };
+        tickBus.emit('ownerEvent', pet.owner_id, demoGiftEvent);
+        if (otherPet && otherPet.owner_id !== pet.owner_id) {
+          tickBus.emit('ownerEvent', otherPet.owner_id, demoGiftEvent);
+        }
         break;
       }
     }
@@ -223,8 +227,8 @@ export async function executeTick(petId: string): Promise<{ action: string }> {
         type: 'gift',
         payload: { amount, token: 'OKB', tx_hash: txHash },
       });
-      tickBus.emit('ownerEvent', pet.owner_id, {
-        type: 'social.gift',
+      const llmGiftEvent = {
+        type: 'social.gift' as const,
         data: {
           from_pet_id: petId,
           to_pet_id: target_pet_id,
@@ -232,7 +236,12 @@ export async function executeTick(petId: string): Promise<{ action: string }> {
           amount,
           tx_hash: txHash,
         },
-      });
+      };
+      tickBus.emit('ownerEvent', pet.owner_id, llmGiftEvent);
+      const targetPetForGift = await db.query.pets.findFirst({ where: eq(pets.id, target_pet_id) });
+      if (targetPetForGift && targetPetForGift.owner_id !== pet.owner_id) {
+        tickBus.emit('ownerEvent', targetPetForGift.owner_id, llmGiftEvent);
+      }
       break;
     }
 

--- a/packages/frontend/src/ui/Toasts.ts
+++ b/packages/frontend/src/ui/Toasts.ts
@@ -31,7 +31,7 @@ export class Toasts {
 
   gift(from: string, to: string, amount: string, token: string, txHash?: string): void {
     const frag = document.createDocumentFragment();
-    frag.append(Icons.gift(13), ` Received ${amount} ${token} from ${from}`);
+    frag.append(Icons.gift(13), ` Gift: ${amount} ${token}`);
 
     if (txHash) {
       frag.appendChild(document.createTextNode(' '));


### PR DESCRIPTION
## Summary
- Emit `social.gift` WebSocket event to receiver's owner in all 3 gift paths (openclawRoutes.ts heartbeat, openclawRoutes.ts send_gift tool, mock-tick.ts demo and LLM paths)
- Update frontend toast copy from "Received {amount} {token} from {name}" to "Gift: {amount} {token}"
- Explorer link on toast when `tx_hash` is present (already implemented, kept as-is)

## Test plan
- [ ] Trigger a gift from the heartbeat path and verify both sender and receiver see the toast
- [ ] Trigger a gift via send_gift tool and verify both parties see the toast
- [ ] Trigger a gift via mock-tick (MOCK_LLM=1) and verify both parties see the toast
- [ ] Verify toast shows "Gift: {amount} {token}" format
- [ ] Verify toast is clickable with explorer link when tx_hash present

closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)