### PR TITLE
feat(ui): wallet modal panel

### DIFF
--- a/packages/frontend/src/ui/HudBar.ts
+++ b/packages/frontend/src/ui/HudBar.ts
@@ -1,5 +1,6 @@
 import { DiaryPanel } from './DiaryPanel';
 import { FriendsPanel } from './FriendsPanel';
+import { WalletPanel } from './WalletPanel';
 import { Icons } from './icons';
 
 interface StatSlot {
@@ -21,12 +22,14 @@ export class HudBar {
   readonly el: HTMLDivElement;
   readonly diaryPanel: DiaryPanel;
   readonly friendsPanel: FriendsPanel;
+  readonly walletPanel: WalletPanel;
 
   private readonly slots: StatSlot[];
 
-  constructor() {
+  constructor(petId?: string, token?: string) {
     this.diaryPanel = new DiaryPanel();
     this.friendsPanel = new FriendsPanel();
+    this.walletPanel = new WalletPanel(petId, token);
 
     this.el = document.createElement('div');
     this.el.id = 'hud-bar';
@@ -89,17 +92,23 @@ export class HudBar {
 
     centerSection.append(diaryBtn, friendsBadge);
 
-    // ── Right: wallet stub ───────────────────────────────────────────
-    const walletSection = document.createElement('div');
-    walletSection.className = 'hud-wallet';
+    // ── Right: wallet button ─────────────────────────────────────────
+    const walletSection = document.createElement('button');
+    walletSection.className = 'hud-wallet hud-btn';
 
     walletSection.appendChild(Icons.wallet());
 
     const walletBalance = document.createElement('span');
     walletBalance.className = 'hud-wallet-balance';
-    walletBalance.textContent = '0.05 OKB';
+    walletBalance.textContent = 'Wallet';
 
     walletSection.appendChild(walletBalance);
+
+    walletSection.addEventListener('click', () => {
+      this.diaryPanel.close();
+      this.friendsPanel.close();
+      this.walletPanel.toggle();
+    });
 
     this.el.append(statsSection, centerSection, walletSection);
   }

--- a/packages/frontend/src/ui/WalletPanel.ts
+++ b/packages/frontend/src/ui/WalletPanel.ts
@@ -1,0 +1,251 @@
+import { Icons } from './icons';
+
+const BACKEND_URL = (import.meta.env.VITE_BACKEND_URL as string | undefined) ?? 'http://localhost:3001';
+
+function truncateAddress(addr: string | null): string {
+  if (!addr) return '0x\u2014\u2014...\u2014\u2014';
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+/** Centered modal overlay showing the pet's wallet info and assets. */
+export class WalletPanel {
+  readonly el: HTMLDivElement;
+  private visible = false;
+  private petId: string | null;
+  private token: string | null;
+  private fullAddress: string | null = null;
+
+  constructor(petId?: string, token?: string) {
+    this.petId = petId ?? null;
+    this.token = token ?? null;
+
+    this.el = document.createElement('div');
+    this.el.id = 'wallet-overlay';
+    this.el.hidden = true;
+
+    const modal = document.createElement('div');
+    modal.id = 'wallet-modal';
+    modal.className = 'ui-panel';
+
+    // ── Header ──────────────────────────────────────────────────────
+    const header = document.createElement('div');
+    header.className = 'wallet-header';
+
+    const title = document.createElement('span');
+    title.className = 'wallet-title';
+    title.append(Icons.wallet(12), ' Wallet');
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'wallet-close-btn';
+    closeBtn.textContent = '✕';
+    closeBtn.addEventListener('click', () => this.close());
+
+    header.append(title, closeBtn);
+
+    // ── Address bar ──────────────────────────────────────────────────
+    const addressBar = document.createElement('div');
+    addressBar.className = 'wallet-address-bar';
+
+    const addressText = document.createElement('span');
+    addressText.className = 'wallet-address-text';
+    addressText.textContent = truncateAddress(null);
+
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'wallet-copy-btn';
+    copyBtn.textContent = 'Copy';
+    copyBtn.addEventListener('click', () => {
+      if (this.fullAddress) {
+        navigator.clipboard.writeText(this.fullAddress).catch(() => {});
+      }
+    });
+
+    const actionRow = document.createElement('div');
+    actionRow.className = 'wallet-action-row';
+
+    const depositBtn = document.createElement('button');
+    depositBtn.className = 'wallet-btn wallet-btn-deposit';
+    depositBtn.textContent = 'Deposit';
+
+    const withdrawBtn = document.createElement('button');
+    withdrawBtn.className = 'wallet-btn wallet-btn-withdraw';
+    withdrawBtn.textContent = 'Withdraw';
+
+    actionRow.append(depositBtn, withdrawBtn);
+    addressBar.append(addressText, copyBtn, actionRow);
+
+    // ── PAW balance row ──────────────────────────────────────────────
+    const pawRow = document.createElement('div');
+    pawRow.className = 'wallet-paw-row';
+
+    const pawLeft = document.createElement('div');
+    pawLeft.className = 'wallet-paw-left';
+
+    const pawIcon = Icons.gift(14);
+    const pawLabel = document.createElement('span');
+    pawLabel.className = 'wallet-paw-label';
+    pawLabel.textContent = 'PAW Balance';
+
+    pawLeft.append(pawIcon, pawLabel);
+
+    const pawRight = document.createElement('div');
+    pawRight.className = 'wallet-paw-right';
+
+    const pawBalance = document.createElement('span');
+    pawBalance.className = 'wallet-paw-balance';
+    pawBalance.textContent = '— PAW';
+
+    const buyBtn = document.createElement('button');
+    buyBtn.className = 'wallet-btn wallet-btn-buy';
+    buyBtn.textContent = 'Buy';
+
+    pawRight.append(pawBalance, buyBtn);
+    pawRow.append(pawLeft, pawRight);
+
+    // ── Token Assets ─────────────────────────────────────────────────
+    const tokensSection = document.createElement('div');
+    tokensSection.className = 'wallet-section';
+
+    const tokensSectionTitle = document.createElement('div');
+    tokensSectionTitle.className = 'wallet-section-title';
+    tokensSectionTitle.textContent = 'Token Assets';
+    tokensSection.appendChild(tokensSectionTitle);
+
+    const TOKEN_CHAINS = [
+      {
+        chain: 'X Layer',
+        tokens: [
+          { symbol: 'OKB', balance: '0.42', usd: '$12.60' },
+          { symbol: 'xETH', balance: '0.01', usd: '$25.00' },
+        ],
+      },
+      {
+        chain: 'Base',
+        tokens: [
+          { symbol: 'ETH', balance: '0.005', usd: '$12.50' },
+        ],
+      },
+    ];
+
+    for (const chainData of TOKEN_CHAINS) {
+      const chainLabel = document.createElement('div');
+      chainLabel.className = 'wallet-chain-label';
+      chainLabel.textContent = chainData.chain;
+      tokensSection.appendChild(chainLabel);
+
+      for (const token of chainData.tokens) {
+        const tokenRow = document.createElement('div');
+        tokenRow.className = 'wallet-token-row';
+
+        const tokenSymbol = document.createElement('span');
+        tokenSymbol.className = 'wallet-token-symbol';
+        tokenSymbol.textContent = token.symbol;
+
+        const tokenBalance = document.createElement('span');
+        tokenBalance.className = 'wallet-token-balance';
+        tokenBalance.textContent = token.balance;
+
+        const tokenUsd = document.createElement('span');
+        tokenUsd.className = 'wallet-token-usd';
+        tokenUsd.textContent = token.usd;
+
+        tokenRow.append(tokenSymbol, tokenBalance, tokenUsd);
+        tokensSection.appendChild(tokenRow);
+      }
+    }
+
+    // ── NFT Assets ───────────────────────────────────────────────────
+    const nftSection = document.createElement('div');
+    nftSection.className = 'wallet-section';
+
+    const nftSectionTitle = document.createElement('div');
+    nftSectionTitle.className = 'wallet-section-title';
+    nftSectionTitle.textContent = 'NFT Assets';
+    nftSection.appendChild(nftSectionTitle);
+
+    const nftGrid = document.createElement('div');
+    nftGrid.className = 'wallet-nft-grid';
+
+    for (let i = 0; i < 8; i++) {
+      const slot = document.createElement('div');
+      slot.className = i === 0 ? 'wallet-nft-slot wallet-nft-slot-filled' : 'wallet-nft-slot wallet-nft-slot-empty';
+
+      if (i === 0) {
+        const img = document.createElement('img');
+        img.src = '/assets/objects/gift.png';
+        img.alt = 'MVP Trophy';
+        img.className = 'wallet-nft-img';
+        const caption = document.createElement('span');
+        caption.className = 'wallet-nft-caption';
+        caption.textContent = 'MVP Trophy';
+        slot.append(img, caption);
+      }
+
+      nftGrid.appendChild(slot);
+    }
+
+    nftSection.appendChild(nftGrid);
+
+    // ── Body ─────────────────────────────────────────────────────────
+    const body = document.createElement('div');
+    body.className = 'wallet-body';
+    body.append(addressBar, pawRow, tokensSection, nftSection);
+
+    modal.append(header, body);
+    this.el.appendChild(modal);
+
+    // Store refs for data updates
+    this._addressText = addressText;
+    this._pawBalance = pawBalance;
+
+    // Close on backdrop click
+    this.el.addEventListener('click', (e) => {
+      if (e.target === this.el) this.close();
+    });
+  }
+
+  private _addressText: HTMLSpanElement;
+  private _pawBalance: HTMLSpanElement;
+
+  open(): void {
+    this.visible = true;
+    this.el.hidden = false;
+    this._fetchData();
+  }
+
+  private _fetchData(): void {
+    if (!this.petId || !this.token) return;
+    fetch(`${BACKEND_URL}/api/pets/${this.petId}`, {
+      headers: { Authorization: `Bearer ${this.token}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<{ wallet_address?: string | null; paw_balance?: string }>;
+      })
+      .then((data) => {
+        this.fullAddress = data.wallet_address ?? null;
+        this._addressText.textContent = truncateAddress(this.fullAddress);
+        const bal = parseFloat(data.paw_balance ?? '0').toFixed(2);
+        this._pawBalance.textContent = `${bal} PAW`;
+      })
+      .catch(() => {
+        // leave defaults
+      });
+  }
+
+  close(): void {
+    this.visible = false;
+    this.el.hidden = true;
+  }
+
+  isOpen(): boolean {
+    return this.visible;
+  }
+
+  toggle(): void {
+    if (this.visible) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+}

--- a/packages/frontend/src/ui/index.ts
+++ b/packages/frontend/src/ui/index.ts
@@ -35,9 +35,9 @@ export function initUI(mount: HTMLElement, petId?: string, token?: string): void
   const nameplate = new Nameplate('My Pet', '0x1234...5678', 'online');
   const chatLog = new ChatLog();
   const toasts = new Toasts();
-  const hudBar = new HudBar();
+  const hudBar = new HudBar(petId, token);
 
-  overlay.append(nameplate.el, chatLog.el, toasts.el, hudBar.el, hudBar.diaryPanel.el, hudBar.friendsPanel.el);
+  overlay.append(nameplate.el, chatLog.el, toasts.el, hudBar.el, hudBar.diaryPanel.el, hudBar.friendsPanel.el, hudBar.walletPanel.el);
   mount.appendChild(overlay);
 
   // Load initial hunger from PAW balance on page open

--- a/packages/frontend/src/ui/styles.css
+++ b/packages/frontend/src/ui/styles.css
@@ -484,6 +484,282 @@
   font-style: italic;
 }
 
+/* ── Wallet overlay ───────────────────────────────────────────────── */
+#wallet-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(74, 55, 40, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+#wallet-overlay[hidden] {
+  display: none;
+}
+
+#wallet-modal {
+  width: min(420px, 92%);
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.wallet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--ui-brown-light);
+  flex-shrink: 0;
+}
+
+.wallet-title {
+  font-family: var(--ui-font-pixel);
+  font-size: 10px;
+  color: var(--ui-brown);
+}
+
+.wallet-close-btn {
+  background: none;
+  border: none;
+  font-size: 14px;
+  color: var(--ui-text-muted);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.wallet-close-btn:hover {
+  color: var(--ui-text);
+}
+
+.wallet-body {
+  padding: 12px 14px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Address bar */
+.wallet-address-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  background: rgba(139, 111, 71, 0.08);
+  border: 1px solid var(--ui-brown-light);
+  border-radius: 6px;
+}
+
+.wallet-address-text {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--ui-text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wallet-copy-btn {
+  background: var(--ui-brown-light);
+  color: var(--ui-text);
+  border: none;
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.wallet-copy-btn:hover {
+  background: var(--ui-brown);
+  color: var(--ui-cream);
+}
+
+.wallet-action-row {
+  display: flex;
+  gap: 6px;
+  width: 100%;
+}
+
+.wallet-btn {
+  border: none;
+  border-radius: 5px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-family: var(--ui-font-body);
+  cursor: pointer;
+}
+
+.wallet-btn-deposit {
+  background: #4a8a52;
+  color: #fff;
+  flex: 1;
+}
+
+.wallet-btn-deposit:hover {
+  background: #3d7545;
+}
+
+.wallet-btn-withdraw {
+  background: #b84040;
+  color: #fff;
+  flex: 1;
+}
+
+.wallet-btn-withdraw:hover {
+  background: #9e3535;
+}
+
+.wallet-btn-buy {
+  background: var(--ui-brown);
+  color: var(--ui-cream);
+  flex-shrink: 0;
+}
+
+.wallet-btn-buy:hover {
+  background: var(--ui-brown-light);
+  color: var(--ui-text);
+}
+
+/* PAW balance row */
+.wallet-paw-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  background: rgba(232, 197, 71, 0.12);
+  border: 1px solid rgba(232, 197, 71, 0.4);
+  border-radius: 6px;
+}
+
+.wallet-paw-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--ui-text);
+}
+
+.wallet-paw-label {
+  font-weight: 600;
+}
+
+.wallet-paw-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wallet-paw-balance {
+  font-family: var(--ui-font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ui-brown);
+}
+
+/* Token Assets section */
+.wallet-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wallet-section-title {
+  font-family: var(--ui-font-pixel);
+  font-size: 8px;
+  color: var(--ui-brown);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.wallet-chain-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--ui-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: 4px;
+}
+
+.wallet-token-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  background: rgba(139, 111, 71, 0.06);
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.wallet-token-symbol {
+  font-weight: 600;
+  color: var(--ui-text);
+  width: 40px;
+  flex-shrink: 0;
+}
+
+.wallet-token-balance {
+  flex: 1;
+  color: var(--ui-text);
+}
+
+.wallet-token-usd {
+  color: var(--ui-text-muted);
+  flex-shrink: 0;
+}
+
+/* NFT grid */
+.wallet-nft-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.wallet-nft-slot {
+  aspect-ratio: 1;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 2px solid var(--ui-brown-light);
+}
+
+.wallet-nft-slot-filled {
+  background: rgba(163, 197, 133, 0.2);
+}
+
+.wallet-nft-slot-empty {
+  background: rgba(139, 111, 71, 0.06);
+  border-style: dashed;
+  opacity: 0.4;
+}
+
+.wallet-nft-img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.wallet-nft-caption {
+  font-size: 8px;
+  color: var(--ui-text-muted);
+  text-align: center;
+  padding: 2px 2px 3px;
+  line-height: 1.2;
+}
+
 /* ── Mobile responsive ────────────────────────────────────────────── */
 @media (max-width: 600px) {
   #chat-log {


### PR DESCRIPTION
## Summary
- Add `WalletPanel.ts` — centered overlay modal mirroring `DiaryPanel` pattern; fetches `GET /api/pets/:id` on `open()` to display truncated wallet address and PAW balance
- Update `HudBar.ts` — wallet section converted to clickable button that toggles `WalletPanel`; closes diary/friends panels when opening wallet
- Update `ui/index.ts` — appends `hudBar.walletPanel.el` to overlay
- Add wallet modal CSS to `styles.css` — address bar with copy + deposit/withdraw buttons, PAW balance row, token assets (X Layer + Base chains hardcoded), NFT 2×4 grid with MVP Trophy in slot 0

## Test plan
- [ ] Click Wallet button in HUD → modal opens
- [ ] Wallet address shows truncated form (or `0x——...——` if null)
- [ ] Copy button copies full address to clipboard
- [ ] PAW balance loads from API
- [ ] Deposit/Withdraw/Buy buttons are no-ops (no errors)
- [ ] Token assets show X Layer (OKB, xETH) and Base (ETH) sections
- [ ] NFT grid shows 8 slots: slot 0 has gift.png, slots 1–7 are dim/empty
- [ ] Opening wallet closes diary and friends panels
- [ ] Backdrop click closes modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)