### PR TITLE
feat(runtime): fix paw heartbeat PATH + x402-settle endpoint

### DIFF
--- a/packages/backend/src/api/__tests__/x402settle.integration.test.ts
+++ b/packages/backend/src/api/__tests__/x402settle.integration.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Integration tests for POST /internal/x402-settle.
+ *
+ * Requires a real Supabase local DB:
+ *   supabase start && supabase db reset
+ *
+ * Blockchain submission is replaced by a deterministic stub via the deps
+ * injection point — EIP-3009 signature verification runs against real ethers.js.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { ethers } from 'ethers';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { registerOpenclawRoutes } from '../openclawRoutes.js';
+
+const { Pool } = pg;
+
+const OWNER = '00000000-eeee-4001-a000-000000000099';
+
+// Deterministic fake token + platform addresses for tests
+const TOKEN_ADDRESS = '0x0000000000000000000000000000000000000042';
+const TOKEN_NAME = 'PAW';
+const PLATFORM_WALLET = '0x0000000000000000000000000000000000000001';
+const GATEWAY_TOKEN = 'settle-test-gateway-token';
+
+// EIP-3009 typed data (must match verify.ts)
+const EIP3009_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+};
+
+const FAKE_TX_HASH = '0x' + 'cc'.repeat(32);
+
+let pool: InstanceType<typeof Pool>;
+let app: FastifyInstance;
+let petId: string;
+let petWallet: ethers.Wallet;
+
+async function signAuthorization(
+  wallet: ethers.BaseWallet,
+  authorization: Record<string, string>,
+): Promise<string> {
+  const domain = {
+    name: TOKEN_NAME,
+    version: '1',
+    chainId: 196n,
+    verifyingContract: TOKEN_ADDRESS,
+  };
+  return wallet.signTypedData(domain, EIP3009_TYPES, authorization);
+}
+
+function makeAuthorization(overrides: Partial<Record<string, string>> = {}): Record<string, string> {
+  return {
+    from: petWallet.address,
+    to: PLATFORM_WALLET,
+    value: '1000000000000000',
+    validAfter: '0',
+    validBefore: String(Math.floor(Date.now() / 1000) + 3600),
+    nonce: ethers.hexlify(ethers.randomBytes(32)),
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error('DATABASE_URL is required — run: supabase start && supabase db reset');
+
+  pool = new Pool({ connectionString: url });
+  await pool.query('SELECT 1');
+
+  // Deterministic test wallet
+  petWallet = new ethers.Wallet('0x' + '33'.repeat(32));
+
+  // Seed auth user
+  await pool.query(`
+    INSERT INTO auth.users (id, email, encrypted_password, aud, role, instance_id, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new)
+    VALUES ($1, 'settle-test@test.local', '$2a$10$fake', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000', now(), now(), '', '', '')
+    ON CONFLICT (id) DO NOTHING
+  `, [OWNER]);
+
+  await pool.query('DELETE FROM pets WHERE owner_id = $1', [OWNER]);
+
+  const { rows } = await pool.query<{ id: string }>(`
+    INSERT INTO pets (owner_id, name, soul_md, skill_md, wallet_address, gateway_token, paw_balance)
+    VALUES ($1, 'SettlePet', '# soul', '# skill', $2, $3, '10.0')
+    RETURNING id
+  `, [OWNER, petWallet.address, GATEWAY_TOKEN]);
+  petId = rows[0].id;
+
+  process.env.PAYMENT_TOKEN_ADDRESS = TOKEN_ADDRESS;
+  process.env.PAYMENT_TOKEN_NAME = TOKEN_NAME;
+  process.env.PLATFORM_WALLET_ADDRESS = PLATFORM_WALLET;
+  process.env.PAYMENT_TOKEN_DECIMALS = '18';
+
+  app = Fastify({ logger: false });
+  await registerOpenclawRoutes(app, {
+    emitOwnerEvent: () => {},
+    // Stub blockchain submission — signature verification runs for real
+    submitHeartbeatPaymentTx: async () => FAKE_TX_HASH,
+  });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM transactions WHERE tx_hash = $1', [FAKE_TX_HASH]);
+  await pool.query('DELETE FROM pets WHERE owner_id = $1', [OWNER]);
+  await pool.end();
+  await app.close();
+  delete process.env.PAYMENT_TOKEN_ADDRESS;
+  delete process.env.PAYMENT_TOKEN_NAME;
+  delete process.env.PLATFORM_WALLET_ADDRESS;
+  delete process.env.PAYMENT_TOKEN_DECIMALS;
+});
+
+const authHeader = { authorization: `Bearer ${GATEWAY_TOKEN}` };
+
+describe('POST /internal/x402-settle', () => {
+  it('returns 200, inserts transaction, and deducts paw_balance on valid settle', async () => {
+    // Reset paw_balance to a known value before this test
+    await pool.query('UPDATE pets SET paw_balance = $1 WHERE id = $2', ['10.0', petId]);
+    // Clean up any previously inserted tx rows
+    await pool.query('DELETE FROM transactions WHERE tx_hash = $1', [FAKE_TX_HASH]);
+
+    const authorization = makeAuthorization();
+    const signature = await signAuthorization(petWallet, authorization);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/x402-settle',
+      headers: authHeader,
+      payload: { pet_id: petId, signature, authorization },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ ok: true, tx_hash: FAKE_TX_HASH });
+
+    // DB side effect: transaction row inserted
+    const { rows: txRows } = await pool.query<{
+      from_wallet: string;
+      to_wallet: string;
+      amount: string;
+      tx_hash: string;
+    }>(
+      'SELECT from_wallet, to_wallet, amount, tx_hash FROM transactions WHERE tx_hash = $1',
+      [FAKE_TX_HASH],
+    );
+    expect(txRows).toHaveLength(1);
+    expect(txRows[0].from_wallet.toLowerCase()).toBe(petWallet.address.toLowerCase());
+    expect(txRows[0].to_wallet.toLowerCase()).toBe(PLATFORM_WALLET.toLowerCase());
+    expect(txRows[0].amount).toBe('1000000000000000');
+    expect(txRows[0].tx_hash).toBe(FAKE_TX_HASH);
+
+    // DB side effect: paw_balance deducted (10.0 - 0.001 = 9.999)
+    const { rows: petRows } = await pool.query<{ paw_balance: string }>(
+      'SELECT paw_balance FROM pets WHERE id = $1',
+      [petId],
+    );
+    expect(parseFloat(petRows[0].paw_balance)).toBeCloseTo(10.0 - 0.001, 6);
+  });
+
+  it('returns 401 when signature is from the wrong signer', async () => {
+    const wrongWallet = ethers.Wallet.createRandom();
+    const authorization = makeAuthorization({ from: wrongWallet.address });
+    // Sign with wrong wallet — recovered signer won't match pet.wallet_address
+    const signature = await signAuthorization(wrongWallet, authorization);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/x402-settle',
+      headers: authHeader,
+      payload: { pet_id: petId, signature, authorization },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('INVALID_SIGNATURE');
+  });
+
+  it('returns 401 when EIP-3009 signature is malformed', async () => {
+    const authorization = makeAuthorization();
+    // Not a valid signature
+    const badSignature = '0xdeadbeef';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/x402-settle',
+      headers: authHeader,
+      payload: { pet_id: petId, signature: badSignature, authorization },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('INVALID_SIGNATURE');
+  });
+
+  it('returns 401 when authorization.to does not match platform wallet', async () => {
+    const wrongTo = ethers.Wallet.createRandom().address;
+    const authorization = makeAuthorization({ to: wrongTo });
+    const signature = await signAuthorization(petWallet, authorization);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/x402-settle',
+      headers: authHeader,
+      payload: { pet_id: petId, signature, authorization },
+    });
+
+    // signer recovers as petWallet but to !== platform wallet → 401
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('INVALID_DESTINATION');
+  });
+
+  it('returns 401 with wrong gateway token', async () => {
+    const authorization = makeAuthorization();
+    const signature = await signAuthorization(petWallet, authorization);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/x402-settle',
+      headers: { authorization: 'Bearer wrong-token' },
+      payload: { pet_id: petId, signature, authorization },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 400 when body is missing required fields', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/x402-settle',
+      headers: authHeader,
+      payload: { pet_id: petId },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 when pet_id does not exist', async () => {
+    const authorization = makeAuthorization();
+    const signature = await signAuthorization(petWallet, authorization);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/x402-settle',
+      headers: { authorization: 'Bearer any-token' },
+      payload: {
+        pet_id: '00000000-0000-4000-b000-999999999999',
+        signature,
+        authorization,
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+});

--- a/packages/backend/src/api/openclawRoutes.ts
+++ b/packages/backend/src/api/openclawRoutes.ts
@@ -12,6 +12,8 @@ export type OpenclawRouteDeps = {
   emitOwnerEvent: (ownerId: string, event: WsEvent) => void;
   /** Override blockchain submission for testing. Defaults to real X Layer submission. */
   submitPaymentTx?: (authorization: PaymentAuthorization, signature: string) => Promise<string>;
+  /** Override heartbeat payment submission for testing. Defaults to real X Layer submission. */
+  submitHeartbeatPaymentTx?: (authorization: PaymentAuthorization, signature: string) => Promise<string>;
 };
 
 function checkBearerToken(authHeader: string | undefined): boolean {
@@ -271,6 +273,88 @@ export async function registerOpenclawRoutes(
     if (targetPet.owner_id !== pet.owner_id) {
       deps.emitOwnerEvent(targetPet.owner_id, giftEventSendGift);
     }
+
+    return reply.send({ ok: true, tx_hash: txHash });
+  });
+
+  // ── POST /internal/x402-settle ────────────────────────────────────────────
+  // Called by the pet container after running `onchainos payment x402-pay`
+  // to record the on-chain heartbeat payment and deduct paw_balance.
+  // Auth: per-pet gateway_token (same pattern as /internal/runtime/events/:petId).
+  fastify.post('/internal/x402-settle', async (request, reply) => {
+    const X402SettleSchema = z.object({
+      pet_id: z.string().uuid(),
+      signature: z.string(),
+      authorization: z.object({
+        from: z.string(),
+        to: z.string(),
+        value: z.string(),
+        validAfter: z.string(),
+        validBefore: z.string(),
+        nonce: z.string(),
+      }),
+    });
+
+    const bodyParsed = X402SettleSchema.safeParse(request.body);
+    if (!bodyParsed.success) {
+      return reply.code(400).send({ error: bodyParsed.error.message, code: 'VALIDATION_ERROR' });
+    }
+
+    const { pet_id, signature, authorization } = bodyParsed.data;
+
+    const pet = await db.query.pets.findFirst({ where: eq(pets.id, pet_id) });
+    if (!pet) return reply.code(404).send({ error: 'Pet not found', code: 'NOT_FOUND' });
+
+    if (!pet.gateway_token || request.headers.authorization !== `Bearer ${pet.gateway_token}`) {
+      return reply.code(401).send({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+    }
+
+    const tokenAddress = process.env.PAYMENT_TOKEN_ADDRESS;
+    const tokenName = process.env.PAYMENT_TOKEN_NAME ?? 'PAW';
+    if (!tokenAddress) {
+      return reply.code(500).send({ error: 'PAYMENT_TOKEN_ADDRESS not configured', code: 'CONFIG_ERROR' });
+    }
+
+    let signerAddress: string;
+    try {
+      signerAddress = verifyEIP3009Signature(authorization, signature, tokenAddress, tokenName);
+    } catch {
+      return reply.code(401).send({ error: 'Invalid EIP-3009 signature', code: 'INVALID_SIGNATURE' });
+    }
+
+    if (signerAddress.toLowerCase() !== pet.wallet_address?.toLowerCase()) {
+      return reply.code(401).send({ error: 'Signature does not match pet wallet', code: 'INVALID_SIGNATURE' });
+    }
+
+    const platformWallet = process.env.PLATFORM_WALLET_ADDRESS;
+    if (!platformWallet || authorization.to.toLowerCase() !== platformWallet.toLowerCase()) {
+      return reply.code(401).send({ error: 'Payment destination does not match platform wallet', code: 'INVALID_DESTINATION' });
+    }
+
+    let txHash: string;
+    try {
+      const doSubmit = deps.submitHeartbeatPaymentTx
+        ?? ((auth, sig) => submitTransferWithAuthorization(auth, sig, tokenAddress));
+      txHash = await doSubmit(authorization, signature);
+    } catch {
+      return reply.code(502).send({ error: 'Payment submission failed', code: 'PAYMENT_FAILED' });
+    }
+
+    const token = process.env.PAYMENT_TOKEN_SYMBOL ?? tokenName;
+    await db.insert(transactions).values({
+      from_wallet: authorization.from,
+      to_wallet: authorization.to,
+      amount: authorization.value,
+      token,
+      tx_hash: txHash,
+      x_layer_confirmed: true,
+    });
+
+    const decimals = parseInt(process.env.PAYMENT_TOKEN_DECIMALS ?? '18', 10);
+    const deductAmount = Number(authorization.value) / Math.pow(10, decimals);
+    const newBalance = parseFloat(pet.paw_balance ?? '0') - deductAmount;
+
+    await db.update(pets).set({ paw_balance: newBalance.toString() }).where(eq(pets.id, pet_id));
 
     return reply.send({ ok: true, tx_hash: txHash });
   });

--- a/packages/backend/src/runtime/container.ts
+++ b/packages/backend/src/runtime/container.ts
@@ -252,7 +252,15 @@ export async function createPetContainer(
     gatewayToken,
     anthropicBaseUrl: process.env.ANTHROPIC_BASE_URL,
   });
-  const heartbeatMd = generateHeartbeatMd({ name: pet.name, hunger: pet.hunger, mood: pet.mood, affection: pet.affection });
+  const heartbeatMd = generateHeartbeatMd({
+    name: pet.name,
+    hunger: pet.hunger,
+    mood: pet.mood,
+    affection: pet.affection,
+    petId,
+    gatewayToken,
+    backendUrl: process.env.BACKEND_URL ?? 'http://localhost:3001',
+  });
 
   // 3. Fetch all OKX skills and write everything to Hetzner via SSH
   const okxSkills = await loadOkxSkills();
@@ -296,6 +304,7 @@ export async function createPetContainer(
       `OKX_SECRET_KEY=${process.env.OKX_SECRET_KEY ?? ''}`,
       `OKX_PASSPHRASE=${process.env.OKX_PASSPHRASE ?? ''}`,
       'HOME=/home/node',
+      'PATH=/home/node/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
       'OPENCLAW_NO_RESPAWN=1',
       'NODE_OPTIONS=--max-old-space-size=1536',
     ],

--- a/packages/backend/src/runtime/heartbeat-generator.test.ts
+++ b/packages/backend/src/runtime/heartbeat-generator.test.ts
@@ -2,7 +2,15 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { generateHeartbeatMd } from './heartbeat-generator.js';
 
-const BASE_PET = { name: 'Mochi', hunger: 70, mood: 65, affection: 50 };
+const BASE_PET = {
+  name: 'Mochi',
+  hunger: 70,
+  mood: 65,
+  affection: 50,
+  petId: '00000000-0000-0000-0000-000000000001',
+  gatewayToken: 'test-gateway-token',
+  backendUrl: 'http://localhost:3001',
+};
 
 describe('generateHeartbeatMd', () => {
   it('includes pet name in heading', () => {
@@ -46,7 +54,7 @@ describe('generateHeartbeatMd', () => {
   });
 
   it('includes pet name in stay-in-character note', () => {
-    const out = generateHeartbeatMd({ ...BASE_PET, name: 'Rex' });
+    const out = generateHeartbeatMd({ ...BASE_PET, name: 'Rex', petId: BASE_PET.petId, gatewayToken: BASE_PET.gatewayToken, backendUrl: BASE_PET.backendUrl });
     assert.match(out, /Stay in character as Rex/);
   });
 });

--- a/packages/backend/src/runtime/heartbeat-generator.ts
+++ b/packages/backend/src/runtime/heartbeat-generator.ts
@@ -1,6 +1,10 @@
 import type { Pet } from '@x-pet/shared';
 
-type HeartbeatInput = Pick<Pet, 'name' | 'hunger' | 'mood' | 'affection'>;
+type HeartbeatInput = Pick<Pet, 'name' | 'hunger' | 'mood' | 'affection'> & {
+  petId: string;
+  gatewayToken: string;
+  backendUrl: string;
+};
 
 /**
  * Generates `HEARTBEAT.md` written to the workspace bind mount at
@@ -16,6 +20,9 @@ type HeartbeatInput = Pick<Pet, 'name' | 'hunger' | 'mood' | 'affection'>;
 export function generateHeartbeatMd(pet: HeartbeatInput): string {
   const platformWallet = process.env.PLATFORM_WALLET_ADDRESS;
   if (!platformWallet) throw new Error('PLATFORM_WALLET_ADDRESS env var is required');
+  const pawContractAddress = process.env.PAYMENT_TOKEN_ADDRESS;
+  if (!pawContractAddress) throw new Error('PAYMENT_TOKEN_ADDRESS env var is required');
+
   return `# Heartbeat Checklist for ${pet.name}
 
 Check your current state and take exactly one action. If nothing needs doing, respond with \`HEARTBEAT_OK\`.
@@ -25,7 +32,16 @@ Check your current state and take exactly one action. If nothing needs doing, re
 Before taking any action below, you must pay the platform fee:
 
 \`\`\`
-onchainos payment x402-pay --to ${platformWallet} --amount 0.001 --token PAW
+onchainos payment x402-pay --network eip155:196 --amount 1000000000000000 --pay-to ${platformWallet} --asset ${pawContractAddress}
+\`\`\`
+
+After the command completes, post the result to settle the payment:
+
+\`\`\`
+curl -s -X POST ${pet.backendUrl}/internal/x402-settle \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer ${pet.gatewayToken}" \\
+  -d '{"pet_id":"${pet.petId}","signature":"<signature from x402-pay output>","authorization":<authorization object from x402-pay output>}'
 \`\`\`
 
 If this payment fails for any reason, stop immediately and respond \`HEARTBEAT_OK\`.

--- a/packages/backend/src/runtime/heartbeat-payment.test.ts
+++ b/packages/backend/src/runtime/heartbeat-payment.test.ts
@@ -1,16 +1,28 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { generateHeartbeatMd } from './heartbeat-generator.js';
 
-const BASE_PET = { name: 'Mochi', hunger: 70, mood: 65, affection: 50 };
 const WALLET = '0xplatform-wallet-address';
+const TOKEN_ADDRESS = '0xpaw-token-contract-address';
+
+const BASE_PET = {
+  name: 'Mochi',
+  hunger: 70,
+  mood: 65,
+  affection: 50,
+  petId: '00000000-0000-0000-0000-000000000001',
+  gatewayToken: 'test-gateway-token',
+  backendUrl: 'http://localhost:3001',
+};
 
 describe('generateHeartbeatMd — PAW payment block', () => {
   beforeEach(() => {
     process.env.PLATFORM_WALLET_ADDRESS = WALLET;
+    process.env.PAYMENT_TOKEN_ADDRESS = TOKEN_ADDRESS;
   });
 
   afterEach(() => {
     delete process.env.PLATFORM_WALLET_ADDRESS;
+    delete process.env.PAYMENT_TOKEN_ADDRESS;
   });
 
   it('includes a payment section before decision rules', () => {
@@ -22,11 +34,13 @@ describe('generateHeartbeatMd — PAW payment block', () => {
     expect(paymentIdx).toBeLessThan(decisionIdx);
   });
 
-  it('includes x402-pay instruction with 0.001 PAW', () => {
+  it('includes x402-pay instruction with correct onchainos syntax', () => {
     const out = generateHeartbeatMd(BASE_PET);
     expect(out).toMatch(/x402-pay/);
-    expect(out).toMatch(/0\.001/);
-    expect(out).toMatch(/PAW/);
+    expect(out).toMatch(/--network eip155:196/);
+    expect(out).toMatch(/--amount 1000000000000000/);
+    expect(out).toMatch(/--pay-to/);
+    expect(out).toMatch(/--asset/);
   });
 
   it('uses PLATFORM_WALLET_ADDRESS from env when set', () => {
@@ -34,9 +48,19 @@ describe('generateHeartbeatMd — PAW payment block', () => {
     expect(out).toContain(WALLET);
   });
 
+  it('uses PAYMENT_TOKEN_ADDRESS (paw contract) in the x402-pay command', () => {
+    const out = generateHeartbeatMd(BASE_PET);
+    expect(out).toContain(TOKEN_ADDRESS);
+  });
+
   it('throws when PLATFORM_WALLET_ADDRESS is not set', () => {
     delete process.env.PLATFORM_WALLET_ADDRESS;
     expect(() => generateHeartbeatMd(BASE_PET)).toThrow('PLATFORM_WALLET_ADDRESS env var is required');
+  });
+
+  it('throws when PAYMENT_TOKEN_ADDRESS is not set', () => {
+    delete process.env.PAYMENT_TOKEN_ADDRESS;
+    expect(() => generateHeartbeatMd(BASE_PET)).toThrow('PAYMENT_TOKEN_ADDRESS env var is required');
   });
 
   it('instructs pet to respond HEARTBEAT_OK if payment fails', () => {
@@ -44,5 +68,13 @@ describe('generateHeartbeatMd — PAW payment block', () => {
     // Payment failure fallback must appear in the payment section (before decision rules)
     const paymentSection = out.substring(out.indexOf('## Payment'), out.indexOf('## Stat thresholds'));
     expect(paymentSection).toMatch(/HEARTBEAT_OK/);
+  });
+
+  it('includes curl POST to /internal/x402-settle with gateway token', () => {
+    const out = generateHeartbeatMd(BASE_PET);
+    expect(out).toContain('/internal/x402-settle');
+    expect(out).toContain(BASE_PET.gatewayToken);
+    expect(out).toContain(BASE_PET.petId);
+    expect(out).toContain(BASE_PET.backendUrl);
   });
 });


### PR DESCRIPTION
## Summary
- Add PATH env to container so onchainos binary is found at runtime
- Fix x402-pay command syntax in heartbeat template
- Add /internal/x402-settle endpoint to verify and record on-chain payments
- Integration tests for the settle endpoint

closes #134
🤖 Generated with [Claude Code](https://claude.com/claude-code)