### PR TITLE
feat(api): replace /internal/x402-settle with /internal/heartbeat/:petId

### DIFF
--- a/packages/backend/src/api/__tests__/heartbeat.integration.test.ts
+++ b/packages/backend/src/api/__tests__/heartbeat.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for POST /internal/x402-settle.
+ * Integration tests for POST /internal/heartbeat/:petId.
  *
  * Requires a real Supabase local DB:
  *   supabase start && supabase db reset
@@ -12,16 +12,17 @@ import pg from 'pg';
 import { ethers } from 'ethers';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { registerOpenclawRoutes } from '../openclawRoutes.js';
+import { buildX402Response } from '../../payment/x402.js';
 
 const { Pool } = pg;
 
-const OWNER = '00000000-eeee-4001-a000-000000000099';
+const OWNER = '00000000-eeee-4002-a000-000000000099';
 
 // Deterministic fake token + platform addresses for tests
 const TOKEN_ADDRESS = '0x0000000000000000000000000000000000000042';
 const TOKEN_NAME = 'PAW';
 const PLATFORM_WALLET = '0x0000000000000000000000000000000000000001';
-const GATEWAY_TOKEN = 'settle-test-gateway-token';
+const GATEWAY_TOKEN = 'heartbeat-test-gateway-token';
 
 // EIP-3009 typed data (must match verify.ts)
 const EIP3009_TYPES = {
@@ -35,7 +36,7 @@ const EIP3009_TYPES = {
   ],
 };
 
-const FAKE_TX_HASH = '0x' + 'cc'.repeat(32);
+const FAKE_TX_HASH = '0x' + 'dd'.repeat(32);
 
 let pool: InstanceType<typeof Pool>;
 let app: FastifyInstance;
@@ -67,6 +68,11 @@ function makeAuthorization(overrides: Partial<Record<string, string>> = {}): Rec
   };
 }
 
+function encodePaymentSignature(authorization: Record<string, string>, signature: string): string {
+  const payload = { authorization, signature };
+  return Buffer.from(JSON.stringify(payload)).toString('base64');
+}
+
 beforeAll(async () => {
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error('DATABASE_URL is required — run: supabase start && supabase db reset');
@@ -75,12 +81,12 @@ beforeAll(async () => {
   await pool.query('SELECT 1');
 
   // Deterministic test wallet
-  petWallet = new ethers.Wallet('0x' + '33'.repeat(32));
+  petWallet = new ethers.Wallet('0x' + '44'.repeat(32));
 
   // Seed auth user
   await pool.query(`
     INSERT INTO auth.users (id, email, encrypted_password, aud, role, instance_id, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new)
-    VALUES ($1, 'settle-test@test.local', '$2a$10$fake', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000', now(), now(), '', '', '')
+    VALUES ($1, 'heartbeat-test@test.local', '$2a$10$fake', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000', now(), now(), '', '', '')
     ON CONFLICT (id) DO NOTHING
   `, [OWNER]);
 
@@ -88,7 +94,7 @@ beforeAll(async () => {
 
   const { rows } = await pool.query<{ id: string }>(`
     INSERT INTO pets (owner_id, name, soul_md, skill_md, wallet_address, gateway_token, paw_balance)
-    VALUES ($1, 'SettlePet', '# soul', '# skill', $2, $3, '10.0')
+    VALUES ($1, 'HeartbeatPet', '# soul', '# skill', $2, $3, '10.0')
     RETURNING id
   `, [OWNER, petWallet.address, GATEWAY_TOKEN]);
   petId = rows[0].id;
@@ -102,7 +108,7 @@ beforeAll(async () => {
   await registerOpenclawRoutes(app, {
     emitOwnerEvent: () => {},
     // Stub blockchain submission — signature verification runs for real
-    submitHeartbeatPaymentTx: async () => FAKE_TX_HASH,
+    submitHeartbeatTx: async () => FAKE_TX_HASH,
   });
   await app.ready();
 });
@@ -120,8 +126,32 @@ afterAll(async () => {
 
 const authHeader = { authorization: `Bearer ${GATEWAY_TOKEN}` };
 
-describe('POST /internal/x402-settle', () => {
-  it('returns 200, inserts transaction, and deducts paw_balance on valid settle', async () => {
+describe('POST /internal/heartbeat/:petId', () => {
+  it('returns 402 on first call with no PAYMENT-SIGNATURE header', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/internal/heartbeat/${petId}`,
+      headers: authHeader,
+    });
+
+    expect(res.statusCode).toBe(402);
+
+    // Body should be base64-encoded X402 requirements
+    const decoded = JSON.parse(Buffer.from(res.body, 'base64').toString('utf8'));
+    expect(decoded).toMatchObject({
+      x402Version: 2,
+      accepts: expect.arrayContaining([
+        expect.objectContaining({
+          network: 'eip155:196',
+          amount: '0.001',
+          payTo: PLATFORM_WALLET,
+          asset: TOKEN_ADDRESS,
+        }),
+      ]),
+    });
+  });
+
+  it('returns 200, inserts transaction, and deducts paw_balance on valid payment', async () => {
     // Reset paw_balance to a known value before this test
     await pool.query('UPDATE pets SET paw_balance = $1 WHERE id = $2', ['10.0', petId]);
     // Clean up any previously inserted tx rows
@@ -129,12 +159,15 @@ describe('POST /internal/x402-settle', () => {
 
     const authorization = makeAuthorization();
     const signature = await signAuthorization(petWallet, authorization);
+    const paymentSignature = encodePaymentSignature(authorization, signature);
 
     const res = await app.inject({
       method: 'POST',
-      url: '/internal/x402-settle',
-      headers: authHeader,
-      payload: { pet_id: petId, signature, authorization },
+      url: `/internal/heartbeat/${petId}`,
+      headers: {
+        ...authHeader,
+        'payment-signature': paymentSignature,
+      },
     });
 
     expect(res.statusCode).toBe(200);
@@ -164,33 +197,39 @@ describe('POST /internal/x402-settle', () => {
     expect(parseFloat(petRows[0].paw_balance)).toBeCloseTo(10.0 - 0.001, 6);
   });
 
-  it('returns 401 when signature is from the wrong signer', async () => {
-    const wrongWallet = ethers.Wallet.createRandom();
-    const authorization = makeAuthorization({ from: wrongWallet.address });
-    // Sign with wrong wallet — recovered signer won't match pet.wallet_address
-    const signature = await signAuthorization(wrongWallet, authorization);
+  it('returns 401 when EIP-3009 signature is malformed', async () => {
+    const authorization = makeAuthorization();
+    // Not a valid signature
+    const badSignature = '0xdeadbeef';
+    const paymentSignature = encodePaymentSignature(authorization, badSignature);
 
     const res = await app.inject({
       method: 'POST',
-      url: '/internal/x402-settle',
-      headers: authHeader,
-      payload: { pet_id: petId, signature, authorization },
+      url: `/internal/heartbeat/${petId}`,
+      headers: {
+        ...authHeader,
+        'payment-signature': paymentSignature,
+      },
     });
 
     expect(res.statusCode).toBe(401);
     expect(res.json().code).toBe('INVALID_SIGNATURE');
   });
 
-  it('returns 401 when EIP-3009 signature is malformed', async () => {
-    const authorization = makeAuthorization();
-    // Not a valid signature
-    const badSignature = '0xdeadbeef';
+  it('returns 401 when signature is from the wrong signer', async () => {
+    const wrongWallet = ethers.Wallet.createRandom();
+    const authorization = makeAuthorization({ from: wrongWallet.address });
+    // Sign with wrong wallet — recovered signer won't match pet.wallet_address
+    const signature = await signAuthorization(wrongWallet, authorization);
+    const paymentSignature = encodePaymentSignature(authorization, signature);
 
     const res = await app.inject({
       method: 'POST',
-      url: '/internal/x402-settle',
-      headers: authHeader,
-      payload: { pet_id: petId, signature: badSignature, authorization },
+      url: `/internal/heartbeat/${petId}`,
+      headers: {
+        ...authHeader,
+        'payment-signature': paymentSignature,
+      },
     });
 
     expect(res.statusCode).toBe(401);
@@ -201,12 +240,15 @@ describe('POST /internal/x402-settle', () => {
     const wrongTo = ethers.Wallet.createRandom().address;
     const authorization = makeAuthorization({ to: wrongTo });
     const signature = await signAuthorization(petWallet, authorization);
+    const paymentSignature = encodePaymentSignature(authorization, signature);
 
     const res = await app.inject({
       method: 'POST',
-      url: '/internal/x402-settle',
-      headers: authHeader,
-      payload: { pet_id: petId, signature, authorization },
+      url: `/internal/heartbeat/${petId}`,
+      headers: {
+        ...authHeader,
+        'payment-signature': paymentSignature,
+      },
     });
 
     // signer recovers as petWallet but to !== platform wallet → 401
@@ -214,46 +256,22 @@ describe('POST /internal/x402-settle', () => {
     expect(res.json().code).toBe('INVALID_DESTINATION');
   });
 
-  it('returns 401 with wrong gateway token', async () => {
-    const authorization = makeAuthorization();
-    const signature = await signAuthorization(petWallet, authorization);
-
+  it('returns 401 when gateway_token is missing or wrong', async () => {
     const res = await app.inject({
       method: 'POST',
-      url: '/internal/x402-settle',
+      url: `/internal/heartbeat/${petId}`,
       headers: { authorization: 'Bearer wrong-token' },
-      payload: { pet_id: petId, signature, authorization },
     });
 
     expect(res.statusCode).toBe(401);
     expect(res.json().code).toBe('UNAUTHORIZED');
   });
 
-  it('returns 400 when body is missing required fields', async () => {
+  it('returns 404 when petId does not exist', async () => {
     const res = await app.inject({
       method: 'POST',
-      url: '/internal/x402-settle',
-      headers: authHeader,
-      payload: { pet_id: petId },
-    });
-
-    expect(res.statusCode).toBe(400);
-    expect(res.json().code).toBe('VALIDATION_ERROR');
-  });
-
-  it('returns 404 when pet_id does not exist', async () => {
-    const authorization = makeAuthorization();
-    const signature = await signAuthorization(petWallet, authorization);
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/internal/x402-settle',
+      url: '/internal/heartbeat/00000000-0000-4000-b000-999999999999',
       headers: { authorization: 'Bearer any-token' },
-      payload: {
-        pet_id: '00000000-0000-4000-b000-999999999999',
-        signature,
-        authorization,
-      },
     });
 
     expect(res.statusCode).toBe(404);

--- a/packages/backend/src/api/openclawRoutes.ts
+++ b/packages/backend/src/api/openclawRoutes.ts
@@ -13,7 +13,7 @@ export type OpenclawRouteDeps = {
   /** Override blockchain submission for testing. Defaults to real X Layer submission. */
   submitPaymentTx?: (authorization: PaymentAuthorization, signature: string) => Promise<string>;
   /** Override heartbeat payment submission for testing. Defaults to real X Layer submission. */
-  submitHeartbeatPaymentTx?: (authorization: PaymentAuthorization, signature: string) => Promise<string>;
+  submitHeartbeatTx?: (authorization: PaymentAuthorization, signature: string) => Promise<string>;
 };
 
 function checkBearerToken(authHeader: string | undefined): boolean {
@@ -277,36 +277,44 @@ export async function registerOpenclawRoutes(
     return reply.send({ ok: true, tx_hash: txHash });
   });
 
-  // ── POST /internal/x402-settle ────────────────────────────────────────────
-  // Called by the pet container after running `onchainos payment x402-pay`
-  // to record the on-chain heartbeat payment and deduct paw_balance.
+  // ── POST /internal/heartbeat/:petId ───────────────────────────────────────
+  // X402 heartbeat payment endpoint called directly by the pet container.
   // Auth: per-pet gateway_token (same pattern as /internal/runtime/events/:petId).
-  fastify.post('/internal/x402-settle', async (request, reply) => {
-    const X402SettleSchema = z.object({
-      pet_id: z.string().uuid(),
-      signature: z.string(),
-      authorization: z.object({
-        from: z.string(),
-        to: z.string(),
-        value: z.string(),
-        validAfter: z.string(),
-        validBefore: z.string(),
-        nonce: z.string(),
-      }),
-    });
-
-    const bodyParsed = X402SettleSchema.safeParse(request.body);
-    if (!bodyParsed.success) {
-      return reply.code(400).send({ error: bodyParsed.error.message, code: 'VALIDATION_ERROR' });
+  //
+  // Flow:
+  //   First call  (no PAYMENT-SIGNATURE header) → HTTP 402 with base64-encoded requirements
+  //   Replay call (PAYMENT-SIGNATURE set)        → verify EIP-3009 sig, submit tx, record, deduct
+  fastify.post('/internal/heartbeat/:petId', async (request, reply) => {
+    const petIdParsed = PetIdSchema.safeParse((request.params as { petId: string }).petId);
+    if (!petIdParsed.success) {
+      return reply.code(400).send({ error: 'Invalid petId', code: 'VALIDATION_ERROR' });
     }
+    const petId = petIdParsed.data;
 
-    const { pet_id, signature, authorization } = bodyParsed.data;
-
-    const pet = await db.query.pets.findFirst({ where: eq(pets.id, pet_id) });
+    const pet = await db.query.pets.findFirst({ where: eq(pets.id, petId) });
     if (!pet) return reply.code(404).send({ error: 'Pet not found', code: 'NOT_FOUND' });
 
     if (!pet.gateway_token || request.headers.authorization !== `Bearer ${pet.gateway_token}`) {
       return reply.code(401).send({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+    }
+
+    const paymentHeader = request.headers['payment-signature'] as string | undefined;
+
+    // ── First call: no payment header → return 402 requirements ──────────────
+    if (!paymentHeader) {
+      const platformWallet = process.env.PLATFORM_WALLET_ADDRESS;
+      if (!platformWallet) {
+        return reply.code(500).send({ error: 'PLATFORM_WALLET_ADDRESS not configured', code: 'CONFIG_ERROR' });
+      }
+      return send402(reply, '0.001', platformWallet);
+    }
+
+    // ── Replay: decode, verify, submit ────────────────────────────────────────
+    let payload: ReturnType<typeof decodePaymentSignature>;
+    try {
+      payload = decodePaymentSignature(paymentHeader);
+    } catch {
+      return reply.code(400).send({ error: 'Invalid PAYMENT-SIGNATURE header', code: 'VALIDATION_ERROR' });
     }
 
     const tokenAddress = process.env.PAYMENT_TOKEN_ADDRESS;
@@ -317,7 +325,7 @@ export async function registerOpenclawRoutes(
 
     let signerAddress: string;
     try {
-      signerAddress = verifyEIP3009Signature(authorization, signature, tokenAddress, tokenName);
+      signerAddress = verifyEIP3009Signature(payload.authorization, payload.signature, tokenAddress, tokenName);
     } catch {
       return reply.code(401).send({ error: 'Invalid EIP-3009 signature', code: 'INVALID_SIGNATURE' });
     }
@@ -327,34 +335,34 @@ export async function registerOpenclawRoutes(
     }
 
     const platformWallet = process.env.PLATFORM_WALLET_ADDRESS;
-    if (!platformWallet || authorization.to.toLowerCase() !== platformWallet.toLowerCase()) {
+    if (!platformWallet || payload.authorization.to.toLowerCase() !== platformWallet.toLowerCase()) {
       return reply.code(401).send({ error: 'Payment destination does not match platform wallet', code: 'INVALID_DESTINATION' });
     }
 
     let txHash: string;
     try {
-      const doSubmit = deps.submitHeartbeatPaymentTx
+      const doSubmit = deps.submitHeartbeatTx
         ?? ((auth, sig) => submitTransferWithAuthorization(auth, sig, tokenAddress));
-      txHash = await doSubmit(authorization, signature);
+      txHash = await doSubmit(payload.authorization, payload.signature);
     } catch {
       return reply.code(502).send({ error: 'Payment submission failed', code: 'PAYMENT_FAILED' });
     }
 
     const token = process.env.PAYMENT_TOKEN_SYMBOL ?? tokenName;
     await db.insert(transactions).values({
-      from_wallet: authorization.from,
-      to_wallet: authorization.to,
-      amount: authorization.value,
+      from_wallet: payload.authorization.from,
+      to_wallet: payload.authorization.to,
+      amount: payload.authorization.value,
       token,
       tx_hash: txHash,
       x_layer_confirmed: true,
     });
 
     const decimals = parseInt(process.env.PAYMENT_TOKEN_DECIMALS ?? '18', 10);
-    const deductAmount = Number(authorization.value) / Math.pow(10, decimals);
+    const deductAmount = Number(payload.authorization.value) / Math.pow(10, decimals);
     const newBalance = parseFloat(pet.paw_balance ?? '0') - deductAmount;
 
-    await db.update(pets).set({ paw_balance: newBalance.toString() }).where(eq(pets.id, pet_id));
+    await db.update(pets).set({ paw_balance: newBalance.toString() }).where(eq(pets.id, petId));
 
     return reply.send({ ok: true, tx_hash: txHash });
   });

--- a/packages/backend/src/runtime/heartbeat-generator.ts
+++ b/packages/backend/src/runtime/heartbeat-generator.ts
@@ -18,33 +18,38 @@ type HeartbeatInput = Pick<Pet, 'name' | 'hunger' | 'mood' | 'affection'> & {
  * right tool even without an explicit tick from the backend.
  */
 export function generateHeartbeatMd(pet: HeartbeatInput): string {
-  const platformWallet = process.env.PLATFORM_WALLET_ADDRESS;
-  if (!platformWallet) throw new Error('PLATFORM_WALLET_ADDRESS env var is required');
-  const pawContractAddress = process.env.PAYMENT_TOKEN_ADDRESS;
-  if (!pawContractAddress) throw new Error('PAYMENT_TOKEN_ADDRESS env var is required');
-
   return `# Heartbeat Checklist for ${pet.name}
 
 Check your current state and take exactly one action. If nothing needs doing, respond with \`HEARTBEAT_OK\`.
 
 ## Payment (required before any action)
 
-Before taking any action below, you must pay the platform fee:
+Before taking any action below, you must pay the platform fee using the x402 payment flow:
+
+**Step 1** — Request payment challenge (expect a 402 response with a base64-encoded requirements body):
 
 \`\`\`
-onchainos payment x402-pay --network eip155:196 --amount 1000000000000000 --pay-to ${platformWallet} --asset ${pawContractAddress}
+curl -s -o /tmp/hb_402.json -w "%{http_code}" -X POST ${pet.backendUrl}/internal/heartbeat/${pet.petId} \\
+  -H "Authorization: Bearer ${pet.gatewayToken}"
 \`\`\`
 
-After the command completes, post the result to settle the payment:
+**Step 2** — Use the \`okx-x402-payment\` skill to complete the payment and obtain a \`PAYMENT-SIGNATURE\`:
 
 \`\`\`
-curl -s -X POST ${pet.backendUrl}/internal/x402-settle \\
-  -H "Content-Type: application/json" \\
+onchainos skill run okx-x402-payment --input "$(cat /tmp/hb_402.json)"
+\`\`\`
+
+**Step 3** — Replay the request with the \`PAYMENT-SIGNATURE\` header:
+
+\`\`\`
+curl -s -X POST ${pet.backendUrl}/internal/heartbeat/${pet.petId} \\
   -H "Authorization: Bearer ${pet.gatewayToken}" \\
-  -d '{"pet_id":"${pet.petId}","signature":"<signature from x402-pay output>","authorization":<authorization object from x402-pay output>}'
+  -H "PAYMENT-SIGNATURE: <base64-encoded PaymentPayload from step 2>"
 \`\`\`
 
-If this payment fails for any reason, stop immediately and respond \`HEARTBEAT_OK\`.
+If the response is \`{"ok":true,...}\`, the payment succeeded. Continue to the stat check below.
+
+If any step fails for any reason, stop immediately and respond \`HEARTBEAT_OK\`.
 
 ## Stat thresholds
 

--- a/packages/backend/src/runtime/heartbeat-payment.test.ts
+++ b/packages/backend/src/runtime/heartbeat-payment.test.ts
@@ -1,8 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { generateHeartbeatMd } from './heartbeat-generator.js';
-
-const WALLET = '0xplatform-wallet-address';
-const TOKEN_ADDRESS = '0xpaw-token-contract-address';
 
 const BASE_PET = {
   name: 'Mochi',
@@ -15,16 +12,6 @@ const BASE_PET = {
 };
 
 describe('generateHeartbeatMd — PAW payment block', () => {
-  beforeEach(() => {
-    process.env.PLATFORM_WALLET_ADDRESS = WALLET;
-    process.env.PAYMENT_TOKEN_ADDRESS = TOKEN_ADDRESS;
-  });
-
-  afterEach(() => {
-    delete process.env.PLATFORM_WALLET_ADDRESS;
-    delete process.env.PAYMENT_TOKEN_ADDRESS;
-  });
-
   it('includes a payment section before decision rules', () => {
     const out = generateHeartbeatMd(BASE_PET);
     const paymentIdx = out.indexOf('## Payment');
@@ -34,33 +21,27 @@ describe('generateHeartbeatMd — PAW payment block', () => {
     expect(paymentIdx).toBeLessThan(decisionIdx);
   });
 
-  it('includes x402-pay instruction with correct onchainos syntax', () => {
+  it('includes curl POST to /internal/heartbeat/:petId with gateway token', () => {
     const out = generateHeartbeatMd(BASE_PET);
-    expect(out).toMatch(/x402-pay/);
-    expect(out).toMatch(/--network eip155:196/);
-    expect(out).toMatch(/--amount 1000000000000000/);
-    expect(out).toMatch(/--pay-to/);
-    expect(out).toMatch(/--asset/);
+    expect(out).toContain(`/internal/heartbeat/${BASE_PET.petId}`);
+    expect(out).toContain(BASE_PET.gatewayToken);
+    expect(out).toContain(BASE_PET.backendUrl);
   });
 
-  it('uses PLATFORM_WALLET_ADDRESS from env when set', () => {
+  it('does NOT contain the old /internal/x402-settle endpoint', () => {
     const out = generateHeartbeatMd(BASE_PET);
-    expect(out).toContain(WALLET);
+    expect(out).not.toContain('/internal/x402-settle');
   });
 
-  it('uses PAYMENT_TOKEN_ADDRESS (paw contract) in the x402-pay command', () => {
+  it('does NOT contain hardcoded x402-pay onchainos parameters', () => {
     const out = generateHeartbeatMd(BASE_PET);
-    expect(out).toContain(TOKEN_ADDRESS);
+    // The new flow uses okx-x402-payment skill, not hardcoded x402-pay params
+    expect(out).not.toMatch(/--network eip155:196.*--amount.*--pay-to.*--asset/s);
   });
 
-  it('throws when PLATFORM_WALLET_ADDRESS is not set', () => {
-    delete process.env.PLATFORM_WALLET_ADDRESS;
-    expect(() => generateHeartbeatMd(BASE_PET)).toThrow('PLATFORM_WALLET_ADDRESS env var is required');
-  });
-
-  it('throws when PAYMENT_TOKEN_ADDRESS is not set', () => {
-    delete process.env.PAYMENT_TOKEN_ADDRESS;
-    expect(() => generateHeartbeatMd(BASE_PET)).toThrow('PAYMENT_TOKEN_ADDRESS env var is required');
+  it('instructs pet to use okx-x402-payment skill to complete payment', () => {
+    const out = generateHeartbeatMd(BASE_PET);
+    expect(out).toContain('okx-x402-payment');
   });
 
   it('instructs pet to respond HEARTBEAT_OK if payment fails', () => {
@@ -68,13 +49,5 @@ describe('generateHeartbeatMd — PAW payment block', () => {
     // Payment failure fallback must appear in the payment section (before decision rules)
     const paymentSection = out.substring(out.indexOf('## Payment'), out.indexOf('## Stat thresholds'));
     expect(paymentSection).toMatch(/HEARTBEAT_OK/);
-  });
-
-  it('includes curl POST to /internal/x402-settle with gateway token', () => {
-    const out = generateHeartbeatMd(BASE_PET);
-    expect(out).toContain('/internal/x402-settle');
-    expect(out).toContain(BASE_PET.gatewayToken);
-    expect(out).toContain(BASE_PET.petId);
-    expect(out).toContain(BASE_PET.backendUrl);
   });
 });


### PR DESCRIPTION
## Summary

- Removes `POST /internal/x402-settle` endpoint (added in PR #135) and replaces it with `POST /internal/heartbeat/:petId` which speaks the x402 protocol natively
- First call with no `PAYMENT-SIGNATURE` header returns HTTP 402 with base64-encoded requirements; replay call with `PAYMENT-SIGNATURE` verifies EIP-3009 sig, submits tx, inserts transaction row, and deducts `paw_balance`
- Updates `heartbeat-generator.ts` HEARTBEAT.md template to use the new 3-step curl flow (request challenge → `okx-x402-payment` skill → replay with `PAYMENT-SIGNATURE`), removing the two-step `onchainos x402-pay` + `/internal/x402-settle` curl pattern
- Renames `submitHeartbeatPaymentTx` dep to `submitHeartbeatTx` in `OpenclawRouteDeps`
- Deletes `x402settle.integration.test.ts` and replaces with `heartbeat.integration.test.ts` covering: first call returns 402, valid payment settles and deducts balance, bad sig returns 401, wrong signer returns 401, wrong destination returns 401, missing gateway_token returns 401, pet not found returns 404
- Updates `heartbeat-payment.test.ts` to assert the new template pattern (contains `/internal/heartbeat`, `okx-x402-payment`, no old `x402-settle`)

## Test plan

- [ ] `supabase start && pnpm --filter @x-pet/backend db:migrate` to set up local DB
- [ ] `supabase db reset` for clean slate
- [ ] `pnpm --filter @x-pet/backend vitest run src/api/__tests__/heartbeat.integration.test.ts`
- [ ] `pnpm --filter @x-pet/backend vitest run src/runtime/heartbeat-payment.test.ts`
- [ ] Verify no references to `/internal/x402-settle` remain in non-test source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)