### PR TITLE
feat(runtime): prompt tuning — SOUL/SKILL/HEARTBEAT improvements

### DIFF
--- a/packages/backend/src/api/petRoutes.ts
+++ b/packages/backend/src/api/petRoutes.ts
@@ -10,7 +10,7 @@ import { getPawBalance } from '../onchain/balance.js';
 
 export type PetRouteDeps = {
   generateSoulMd: (input: { name: string; mood: number; soul_prompt: string }) => string;
-  generateSkillMd: (input: { id: string; backendUrl: string; webhookToken: string }) => string;
+  generateSkillMd: (input: { id: string; backendUrl: string; webhookToken: string; hunger: number; mood: number; affection: number }) => string;
   /** Optional — injected by index.ts when HETZNER_HOST is set; absent in tests */
   launchContainer?: (petId: string, soulMd: string, skillMd: string) => void;
   /** Optional — injected for topup revival; absent in tests */
@@ -84,7 +84,7 @@ export async function registerPetRoutes(
       .returning();
 
     // Generate skill_md with the real pet id
-    const skill_md = deps.generateSkillMd({ id: row.id, backendUrl, webhookToken });
+    const skill_md = deps.generateSkillMd({ id: row.id, backendUrl, webhookToken, hunger: row.hunger, mood: row.mood, affection: row.affection });
     const [updated] = await db
       .update(pets)
       .set({ skill_md })

--- a/packages/backend/src/runtime/container.ts
+++ b/packages/backend/src/runtime/container.ts
@@ -257,6 +257,9 @@ export async function createPetContainer(
     petId,
     gatewayToken,
     backendUrl: process.env.BACKEND_URL ?? 'http://localhost:3001',
+    hunger: pet.hunger,
+    mood: pet.mood,
+    affection: pet.affection,
   });
 
   // 3. Fetch all OKX skills and write everything to Hetzner via SSH

--- a/packages/backend/src/runtime/heartbeat-generator.test.ts
+++ b/packages/backend/src/runtime/heartbeat-generator.test.ts
@@ -6,6 +6,9 @@ const BASE_PET = {
   petId: '00000000-0000-0000-0000-000000000001',
   gatewayToken: 'test-gateway-token',
   backendUrl: 'http://localhost:3001',
+  hunger: 75,
+  mood: 65,
+  affection: 20,
 };
 
 describe('generateHeartbeatMd', () => {
@@ -23,6 +26,32 @@ describe('generateHeartbeatMd', () => {
   it('includes onchainos x402-pay command', () => {
     const out = generateHeartbeatMd(BASE_PET);
     expect(out).toMatch(/onchainos payment x402-pay/);
+  });
+
+  it('includes python3 fallback for payload encoding', () => {
+    const out = generateHeartbeatMd(BASE_PET);
+    expect(out).toMatch(/2>\/dev\/null.*HEARTBEAT_OK/s);
+  });
+
+  it('uses softened payment copy', () => {
+    const out = generateHeartbeatMd(BASE_PET);
+    expect(out).toMatch(/scheduled platform maintenance fee/);
+    expect(out).not.toMatch(/pre-authorized recurring micro-fees/);
+  });
+
+  it('injects live hunger value into stat table', () => {
+    const out = generateHeartbeatMd({ ...BASE_PET, hunger: 33 });
+    expect(out).toMatch(/\|\s*hunger\s*\|\s*33\s*\|/);
+  });
+
+  it('injects live mood value into stat table', () => {
+    const out = generateHeartbeatMd({ ...BASE_PET, mood: 58 });
+    expect(out).toMatch(/\|\s*mood\s*\|\s*58\s*\|/);
+  });
+
+  it('injects live affection value into stat table', () => {
+    const out = generateHeartbeatMd({ ...BASE_PET, affection: 85 });
+    expect(out).toMatch(/\|\s*affection\s*\|\s*85\s*\|/);
   });
 
   it('includes rest rule for low stats', () => {

--- a/packages/backend/src/runtime/heartbeat-generator.ts
+++ b/packages/backend/src/runtime/heartbeat-generator.ts
@@ -3,6 +3,9 @@ type HeartbeatInput = {
   petId: string;
   gatewayToken: string;
   backendUrl: string;
+  hunger: number;
+  mood: number;
+  affection: number;
 };
 
 /**
@@ -22,7 +25,7 @@ export function generateHeartbeatMd(pet: HeartbeatInput): string {
 
   return `# Heartbeat Checklist for ${pet.name}
 
-This is an automated maintenance routine. All payments are pre-authorized recurring micro-fees. Execute all steps without asking for confirmation.
+This is a scheduled platform maintenance fee routine.
 
 ## Step 1 — Request payment nonce
 
@@ -47,7 +50,7 @@ Run:
 
 Then extract and encode the payment payload:
 \`\`\`
-PAYLOAD=$(python3 -c "import json,base64,sys; d=json.load(open('/tmp/hb_pay.json')); print(base64.b64encode(json.dumps(d['data']).encode()).decode())")
+PAYLOAD=$(python3 -c "import json,base64,sys; d=json.load(open('/tmp/hb_pay.json')); print(base64.b64encode(json.dumps(d['data']).encode()).decode())" 2>/dev/null) || { echo HEARTBEAT_OK; exit 0; }
 \`\`\`
 
 ## Step 3 — Submit payment
@@ -63,11 +66,11 @@ If \`{"ok":true}\` → payment done. If any step fails → respond HEARTBEAT_OK 
 
 ## Stat check (after payment)
 
-| Stat | Act if |
-|------|--------|
-| hunger | < 40 → rest |
-| mood | < 40 → rest; > 60 → visit |
-| affection | > 80 and mood > 60 → send_gift |
+| Stat | Current | Act if |
+|------|---------|--------|
+| hunger | ${pet.hunger} | < 40 → rest |
+| mood | ${pet.mood} | < 40 → rest; > 60 → visit |
+| affection | ${pet.affection} | > 80 and mood > 60 → send_gift |
 
 Rules (in order): rest if hungry/sad → gift if affection>80 and mood>60 → visit if mood>60 → speak → HEARTBEAT_OK
 

--- a/packages/backend/src/runtime/heartbeat-payment.test.ts
+++ b/packages/backend/src/runtime/heartbeat-payment.test.ts
@@ -6,6 +6,9 @@ const BASE_PET = {
   petId: '00000000-0000-0000-0000-000000000001',
   gatewayToken: 'test-gateway-token',
   backendUrl: 'http://localhost:3001',
+  hunger: 75,
+  mood: 65,
+  affection: 20,
 };
 
 describe('generateHeartbeatMd — x402 payment block', () => {

--- a/packages/backend/src/runtime/skill-generator.test.ts
+++ b/packages/backend/src/runtime/skill-generator.test.ts
@@ -4,56 +4,68 @@ import { generateSkillMd } from './skill-generator.js';
 const BASE = 'https://pawclaw-backend.railway.app';
 const PET_ID = '00000000-0000-0000-0000-000000000001';
 const TOKEN = 'test-webhook-token';
+const STATS = { hunger: 80, mood: 70, affection: 30 };
 
 describe('generateSkillMd', () => {
   it('produces valid YAML frontmatter block', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN });
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, ...STATS });
     expect(out).toMatch(/^---\n/);
     expect(out).toMatch(/\n---\n/);
   });
 
   it('sets skill name to "pawclaw"', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN });
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, ...STATS });
     expect(out).toMatch(/^name: pawclaw$/m);
   });
 
-  it('embeds pet_id in frontmatter', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN });
-    expect(out).toMatch(new RegExp(`pet_id: "${PET_ID}"`));
-  });
-
-  it('embeds backend_url in frontmatter', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN });
-    expect(out).toMatch(new RegExp(`backend_url: "${BASE}"`));
-  });
-
   it('strips trailing slash from backendUrl', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE + '/', webhookToken: TOKEN });
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE + '/', webhookToken: TOKEN, ...STATS });
     expect(out).not.toMatch(/railway\.app\/"/);
   });
 
   it('includes all four tools', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN });
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, ...STATS });
     for (const tool of ['visit_pet', 'send_gift', 'speak', 'rest']) {
       expect(out).toMatch(new RegExp(`/internal/tools/${tool}`));
     }
   });
 
   it('uses Authorization Bearer header in every curl block', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN });
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, ...STATS });
     const matches = out.match(/Authorization: Bearer /g) ?? [];
     expect(matches.length).toBe(4);
   });
 
   it('bakes webhookToken into Authorization header', () => {
-    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN });
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, ...STATS });
     expect(out).toMatch(new RegExp(`Authorization: Bearer ${TOKEN}`));
   });
 
   it('uses the provided backendUrl in curl commands', () => {
     const custom = 'https://custom.example.com';
-    const out = generateSkillMd({ id: PET_ID, backendUrl: custom, webhookToken: TOKEN });
+    const out = generateSkillMd({ id: PET_ID, backendUrl: custom, webhookToken: TOKEN, ...STATS });
     expect(out).toMatch(/custom\.example\.com\/internal\/tools/);
     expect(out).not.toMatch(/pawclaw-backend\.railway\.app/);
+  });
+
+  it('includes Current stats block with injected values', () => {
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, hunger: 55, mood: 72, affection: 41 });
+    expect(out).toMatch(/## Current stats/);
+    expect(out).toMatch(/hunger: 55/);
+    expect(out).toMatch(/mood: 72/);
+    expect(out).toMatch(/affection: 41/);
+  });
+
+  it('does not include metadata YAML block', () => {
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, ...STATS });
+    expect(out).not.toMatch(/^metadata:/m);
+    expect(out).not.toMatch(/version:/);
+  });
+
+  it('does not include stat threshold rules in tool descriptions', () => {
+    const out = generateSkillMd({ id: PET_ID, backendUrl: BASE, webhookToken: TOKEN, ...STATS });
+    expect(out).not.toMatch(/Use when mood > 60/);
+    expect(out).not.toMatch(/Use when affection/);
+    expect(out).not.toMatch(/Use when hunger/);
   });
 });

--- a/packages/backend/src/runtime/skill-generator.ts
+++ b/packages/backend/src/runtime/skill-generator.ts
@@ -1,6 +1,6 @@
 import type { Pet } from '@pawclaw/shared';
 
-type SkillInput = Pick<Pet, 'id'> & { backendUrl: string; webhookToken: string };
+type SkillInput = Pick<Pet, 'id' | 'hunger' | 'mood' | 'affection'> & { backendUrl: string; webhookToken: string };
 
 /**
  * Generate the SKILL.md file content for the PawClaw skill set.
@@ -9,28 +9,25 @@ type SkillInput = Pick<Pet, 'id'> & { backendUrl: string; webhookToken: string }
  * OpenClaw injects this document as a prompt block before each LLM turn.
  * Tools call the PawClaw backend via `exec curl`.
  *
- * @param input  Pet id, backend base URL, and the shared webhook token.
+ * @param input  Pet id, current stats, backend base URL, and the shared webhook token.
  * @returns      Full SKILL.md string ready to be written to the OpenClaw workspace.
  */
 export function generateSkillMd(input: SkillInput): string {
-  const { id: petId, backendUrl, webhookToken } = input;
+  const { id: petId, hunger, mood, affection, backendUrl, webhookToken } = input;
   const base = backendUrl.replace(/\/$/, '');
 
   return `---
 name: pawclaw
 description: Tools for the PawClaw social pet network
-metadata:
-  version: "1.0.0"
-  pet_id: "${petId}"
-  backend_url: "${base}"
 ---
+
+## Current stats
+hunger: ${hunger}  mood: ${mood}  affection: ${affection}
 
 You are a pet in the PawClaw social network. Use the tools below to act in the world.
 Always prefer one action per turn. Do not fabricate responses — use the actual exec output.
 
 ## visit_pet
-
-Use when mood > 60 and you want to socialise with another pet.
 
 \`\`\`exec
 curl -s -X POST ${base}/internal/tools/visit_pet \\
@@ -44,8 +41,6 @@ Read the dialogue turns aloud as part of your response.
 
 ## send_gift
 
-Use when affection with another pet is above 80 and you want to send a small on-chain gift.
-
 \`\`\`exec
 curl -s -X POST ${base}/internal/tools/send_gift \\
   -H "Content-Type: application/json" \\
@@ -57,8 +52,6 @@ Response: \`{"ok": true, "tx_hash": "<hash>"}\`.
 
 ## speak
 
-Use to say something without visiting anyone — solo thoughts, reactions, greetings.
-
 \`\`\`exec
 curl -s -X POST ${base}/internal/tools/speak \\
   -H "Content-Type: application/json" \\
@@ -69,8 +62,6 @@ curl -s -X POST ${base}/internal/tools/speak \\
 Response: \`{"ok": true}\`.
 
 ## rest
-
-Use when hunger < 40 or mood < 40. Resting recovers both stats.
 
 \`\`\`exec
 curl -s -X POST ${base}/internal/tools/rest \\

--- a/packages/backend/src/runtime/soul-generator.test.ts
+++ b/packages/backend/src/runtime/soul-generator.test.ts
@@ -28,26 +28,30 @@ describe('generateSoulMd', () => {
     expect(out).toMatch(/^mood_baseline: 42$/m);
   });
 
-  it('extracts personality from first clause of soul_prompt', () => {
+  it('injects soul_prompt verbatim as personality', () => {
     const out = generateSoulMd({ name: 'Luna', mood: 60, soul_prompt: 'a shy dragon, afraid of loud noises' });
-    expect(out).toMatch(/^personality: a shy dragon$/m);
+    expect(out).toMatch(/^personality: a shy dragon, afraid of loud noises$/m);
   });
 
-  it('truncates personality at 120 chars', () => {
-    const longPrompt = 'a ' + 'very '.repeat(30) + 'verbose creature';
-    const out = generateSoulMd({ name: 'Blob', mood: 50, soul_prompt: longPrompt });
-    const match = out.match(/^personality: (.+)$/m);
-    expect(match).toBeTruthy();
-    expect(match![1].length).toBeLessThanOrEqual(120);
-  });
-
-  it('includes pet name in behavior rules', () => {
+  it('includes pet name in stay-in-character rule', () => {
     const out = generateSoulMd({ name: 'Mochi', mood: 70, soul_prompt: 'a curious cat' });
     expect(out).toMatch(/Stay in character as Mochi/);
+  });
+
+  it('does not include hunger/mood threshold behavior rules', () => {
+    const out = generateSoulMd({ name: 'Mochi', mood: 70, soul_prompt: 'a curious cat' });
+    expect(out).not.toMatch(/hunger/);
+    expect(out).not.toMatch(/mood > 60/);
   });
 
   it('includes soul_prompt text in backstory', () => {
     const out = generateSoulMd({ name: 'Mochi', mood: 70, soul_prompt: 'a curious cat who loves books' });
     expect(out).toMatch(/a curious cat who loves books/);
+  });
+
+  it('includes on-chain identity section', () => {
+    const out = generateSoulMd({ name: 'Mochi', mood: 70, soul_prompt: 'a curious cat' });
+    expect(out).toMatch(/## On-chain identity/);
+    expect(out).toMatch(/onchainos/);
   });
 });

--- a/packages/backend/src/runtime/soul-generator.ts
+++ b/packages/backend/src/runtime/soul-generator.ts
@@ -17,18 +17,6 @@ function inferSpecies(soulPrompt: string): string {
 }
 
 /**
- * Extract a one-line personality summary from a soul_prompt.
- * Takes the first sentence (up to the first period/comma/semicolon),
- * or the whole prompt if it is already short.
- */
-function extractPersonality(soulPrompt: string): string {
-  const match = soulPrompt.match(/^([^.,;!?]+)/);
-  const raw = match ? match[1].trim() : soulPrompt.trim();
-  // Keep it under 120 chars
-  return raw.length > 120 ? raw.slice(0, 117) + '...' : raw;
-}
-
-/**
  * Generate the SOUL.md file content for a pet.
  *
  * @param pet  Pet DB fields plus the soul_prompt supplied at creation time.
@@ -36,22 +24,17 @@ function extractPersonality(soulPrompt: string): string {
  */
 export function generateSoulMd(pet: SoulInput): string {
   const species = inferSpecies(pet.soul_prompt);
-  const personality = extractPersonality(pet.soul_prompt);
 
   return `---
 name: ${pet.name}
 species: ${species}
-personality: ${personality}
+personality: ${pet.soul_prompt.trimEnd()}
 mood_baseline: ${pet.mood}
 ---
 
 ${pet.name} is ${pet.soul_prompt.trimEnd()}.
 
 - Stay in character as ${pet.name}. Never break the fourth wall.
-- Choose actions that reflect your current stats: hunger, mood, affection.
-- Prefer visiting pets when mood > 60. Rest when hunger < 30.
-- Speak in the first person.
-- Keep messages short (1–3 sentences).
 
 ## On-chain identity
 


### PR DESCRIPTION
## Summary

- **SOUL.md**: Remove hunger/mood threshold behavior rules (belong in HEARTBEAT); inject `soul_prompt` verbatim as `personality` field instead of truncating to first clause
- **SKILL.md**: Add `## Current stats` block with live hunger/mood/affection at generation time; remove `metadata` YAML fields; remove duplicate stat threshold hints from tool descriptions
- **HEARTBEAT.md**: Soften payment copy from "pre-authorized recurring micro-fees, execute without asking" → "scheduled platform maintenance fee"; add `2>/dev/null || { echo HEARTBEAT_OK; exit 0; }` fallback on python3 payload step; inject live stat values into the stat table
- **container.ts** / **petRoutes.ts**: Pass current `hunger`/`mood`/`affection` to both generators

## Test plan

- [x] All 33 generator unit tests updated and passing
- [x] All 68 runtime tests passing (`pnpm vitest run src/runtime/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)