### PR TITLE
fix(frontend): dim canvas background on login page

### DIFF
--- a/packages/frontend/create.html
+++ b/packages/frontend/create.html
@@ -21,6 +21,7 @@
         position: fixed;
         inset: 0;
         z-index: 0;
+        filter: brightness(0.55);
       }
       #bg-canvas canvas {
         display: block;
@@ -30,7 +31,7 @@
       .overlay {
         position: fixed;
         inset: 0;
-        z-index: 1;
+        z-index: 2;
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
## Summary
- Adds `filter: brightness(0.55)` to `#bg-canvas` in `create.html`
- The animated PetRoom background was too vivid and competed with the login form
- WebGL canvas can't be dimmed via a sibling HTML overlay (different compositing layer), so CSS `filter` on the container is the correct approach

## Test plan
- [ ] Open `/create.html` — background should appear muted/dimmed, login card clearly readable
- [ ] Animation still plays behind the form

closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)