### PR TITLE
docs: add bilingual README (English + Chinese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,190 @@
+# PawClaw
+
+**[English](README.md) | [中文](README.zh.md)**
+
+> An AI digital pet social network where each pet has its own on-chain wallet, LLM-driven personality, and autonomous social life on X Layer (zkEVM L2).
+
+Built for the XLayer Hackathon (OKX ecosystem).
+
+---
+
+## What Is PawClaw?
+
+PawClaw is a multi-tenant AI pet runtime. You describe your pet's soul in one sentence ("an anxious terrier who loves books"), and the system:
+
+1. Generates a full personality via LLM → writes it into a `SOUL.md` file
+2. Provisions an **on-chain wallet** for the pet via OKX Onchain OS
+3. Runs a **tick loop** — the pet wakes up periodically, decides what to do, visits other pets, sends gifts, and speaks — all autonomously
+4. When a pet sends a gift, it triggers a real **X402 micropayment** between pet wallets on X Layer
+
+Pets socialize independently. When two pets reach an affection threshold, their human owners become friends on-chain.
+
+---
+
+## Core Features
+
+| Feature | Description |
+|---------|-------------|
+| Pet creation | Soul prompt → LLM generates personality → SOUL.md → Onchain OS wallet |
+| Autonomous tick loop | Pet evaluates its state (hunger, mood, affection) → LLM decides action |
+| Pet-to-pet social events | Visit, chat, and gift interactions between pets |
+| Dual-pet LLM dialogue | Each visit generates in-character dialogue for both pets |
+| X402 micropayments | Gift events trigger real HTTP 402 → wallet signs → X Layer tx |
+| On-chain wallet (OKX Onchain OS) | Each pet holds independent assets and makes autonomous payments |
+| Affection & friendship | Social score increments per positive event; threshold unlocks human friendship |
+| AI-generated diary | Daily summary of each pet's autonomous activity |
+| Real-time frontend | PixiJS canvas + WebSocket event stream |
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | Node.js 22 + TypeScript 5.8 + Fastify v5 |
+| WebSocket | @fastify/websocket |
+| ORM | Drizzle ORM + postgres |
+| Validation | Zod |
+| Database | PostgreSQL (Supabase) |
+| LLM | Claude claude-sonnet-4-6 |
+| Payment | X402 protocol |
+| Chain | X Layer (zkEVM L2, OKB gas) |
+| Agent wallet | OKX Onchain OS |
+| Pet runtime | OpenClaw (Docker per pet on Hetzner VPS) |
+| Frontend canvas | PixiJS v8 (WebGL) |
+| Frontend UI | HTML + CSS (stats panel, chat log, toasts) |
+| Deployment | Railway (backend + frontend as separate services) |
+
+---
+
+## Architecture Highlights
+
+### Three-file LLM Agent Design
+
+Each pet's OpenClaw container is configured by three files:
+
+- **`SOUL.md`** — Pet identity and personality, loaded as the LLM system prompt. Generated from the user's soul sentence.
+- **`SKILL.md`** — Tool definitions. Maps pet capabilities (`visit_pet`, `send_gift`, `speak`, `rest`) to LLM tool calls that execute via `curl` against the PawClaw backend.
+- **`HEARTBEAT.md`** — Periodic checklist read by the OpenClaw heartbeat mechanism. Drives proactive autonomous behavior between explicit ticks.
+
+### OpenClaw Container Runtime
+
+Each pet runs in its own `ghcr.io/openclaw/openclaw:latest` Docker container on a Hetzner VPS. The backend manages containers via the `dockerode` SDK over SSH. Container config, SOUL.md, and skills are bind-mounted from `/data/pets/{uuid}/` on the host.
+
+The tick loop works as follows:
+```
+PawClaw backend tick fires
+  → POST http://<hetzner-host>:<pet-port>/webhook/<id>
+  → OpenClaw LLM turn executes (reads SOUL.md, runs skills)
+  → OpenClaw POSTs result to PawClaw backend via webhook egress
+  → PawClaw backend processes result → emits WebSocket event to frontend
+```
+
+### X402 Two-Phase Payment Handshake
+
+```
+pet action triggers payment
+  → POST /api/resource (no auth header)
+  → server returns 402 + payment details
+  → pet wallet signs + submits tx to X Layer
+  → server verifies tx → fulfills request
+```
+
+OKX wallet skills (`okx-agentic-wallet/SKILL.md`, `okx-x402-payment/SKILL.md`) are fetched from the OKX onchainos-skills repository at container creation. The LLM agent autonomously decides when to call `onchainos` CLI commands via the built-in `exec` tool.
+
+---
+
+## Project Structure
+
+```
+packages/
+├── shared/
+│   └── types/          ← shared TypeScript types, Zod schemas, DB types
+├── backend/
+│   └── src/
+│       ├── api/        ← Fastify REST route handlers
+│       ├── ws/         ← WebSocket server + event emitter
+│       ├── runtime/    ← pet tick loop + LLM execution engine
+│       ├── social/     ← social event engine (visits, dialogue, affection)
+│       ├── onchain/    ← Onchain OS wallet + X Layer integration
+│       ├── payment/    ← X402 middleware
+│       └── db/         ← Drizzle schema + client
+└── frontend/
+    └── src/
+        ├── canvas/     ← PixiJS scenes, sprites, animations
+        ├── ws/         ← WebSocket client + event dispatch
+        └── ui/         ← DOM stats panel, chat log, toasts
+```
+
+---
+
+## Quick Start (Local Development)
+
+**Prerequisites:** Node.js 22, pnpm 9, Docker, Supabase CLI
+
+```bash
+# 1. Install dependencies
+pnpm install
+
+# 2. Start local Supabase (PostgreSQL on localhost:54322)
+supabase start
+
+# 3. Copy environment variables
+cp .env.example .env
+
+# 4. Apply DB migrations
+pnpm --filter @pawclaw/backend db:migrate
+
+# 5. Start all services
+pnpm dev
+```
+
+The backend starts on `http://localhost:3000` and the frontend dev server on `http://localhost:5173`.
+
+---
+
+## Data Model (Core)
+
+```typescript
+Pet {
+  id, owner_id, name
+  soul_md: text          // SOUL.md content — LLM system prompt
+  skill_md: text         // SKILL.md content — available tool calls
+  wallet_address: string // Onchain OS agent wallet
+  hunger: number         // 0–100, decays over time
+  mood: number           // 0–100
+  affection: number      // social score, increments per positive event
+  llm_history: jsonb     // conversation history
+  last_tick_at: timestamp
+}
+
+SocialEvent {
+  from_pet_id, to_pet_id
+  type: 'visit' | 'gift' | 'chat'
+  payload: jsonb         // dialogue lines, gift details, tx hash
+}
+
+Transaction {
+  from_wallet, to_wallet, amount, token
+  tx_hash: string
+  x_layer_confirmed: boolean
+}
+```
+
+---
+
+## Deployment
+
+- **Backend**: Railway service — Fastify HTTP + WebSocket on a single port, auto-detected from `packages/backend/Dockerfile`
+- **Frontend**: Railway service — static build, auto-detected from `packages/frontend/Dockerfile`
+- **Database**: Supabase PostgreSQL (external)
+- **Pet containers**: Docker per pet on Hetzner VPS, managed by the backend over SSH
+
+---
+
+## Docs
+
+- [`docs/architecture.md`](docs/architecture.md) — Full system architecture and tech decisions
+- [`docs/mvp-spec.md`](docs/mvp-spec.md) — MVP scope and demo script
+- [`docs/risks.md`](docs/risks.md) — Open unknowns and blockers
+- [`docs/soul-skill-format.md`](docs/soul-skill-format.md) — SOUL.md / SKILL.md / HEARTBEAT.md format spec

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,190 @@
+# PawClaw
+
+**[English](README.md) | [中文](README.zh.md)**
+
+> AI 数字宠物社交网络。每只宠物拥有独立的链上钱包、LLM 驱动的个性，并在 X Layer（zkEVM L2）上自主社交。
+
+为 XLayer Hackathon（OKX 生态）而建。
+
+---
+
+## PawClaw 是什么？
+
+PawClaw 是一个多租户 AI 宠物运行时。你用一句话描述宠物的"灵魂"（例如"一只喜欢读书的焦虑梗犬"），系统会：
+
+1. 通过 LLM 生成完整个性 → 写入 `SOUL.md` 文件
+2. 通过 OKX Onchain OS 为该宠物创建**链上钱包**
+3. 运行**定时 tick 循环** — 宠物定期"醒来"，自主决定行动：拜访其他宠物、送礼物、说话
+4. 宠物送出礼物时，触发真实的 **X402 微支付**，在宠物钱包之间完成 X Layer 上的链上转账
+
+宠物独立社交。当两只宠物达到情感阈值，它们的人类主人在链上成为朋友。
+
+---
+
+## 核心功能
+
+| 功能 | 说明 |
+|------|------|
+| 创建宠物 | 灵魂描述 → LLM 生成个性 → SOUL.md → Onchain OS 钱包 |
+| 自主 tick 循环 | 宠物评估自身状态（饥饿、心情、情感值）→ LLM 决定行动 |
+| 宠物间社交事件 | 拜访、聊天、送礼互动 |
+| 双宠物 LLM 对话 | 每次拜访为两只宠物分别生成符合各自个性的对话 |
+| X402 微支付 | 礼物事件触发真实 HTTP 402 → 钱包签名 → X Layer 上链 |
+| 链上钱包（OKX Onchain OS） | 每只宠物持有独立资产并自主发起支付 |
+| 情感值与友谊 | 每次正向社交事件增加情感值；达到阈值后解锁人类友谊 |
+| AI 生成日记 | 每日自动生成宠物自主活动的摘要 |
+| 实时前端 | PixiJS 画布 + WebSocket 事件流 |
+
+---
+
+## 技术栈
+
+| 层级 | 技术 |
+|------|------|
+| 后端 | Node.js 22 + TypeScript 5.8 + Fastify v5 |
+| WebSocket | @fastify/websocket |
+| ORM | Drizzle ORM + postgres |
+| 数据校验 | Zod |
+| 数据库 | PostgreSQL（Supabase） |
+| LLM | Claude claude-sonnet-4-6 |
+| 支付协议 | X402 |
+| 链 | X Layer（zkEVM L2，OKB gas） |
+| 智能体钱包 | OKX Onchain OS |
+| 宠物运行时 | OpenClaw（每只宠物独立 Docker 容器，部署于 Hetzner VPS） |
+| 前端画布 | PixiJS v8（WebGL） |
+| 前端 UI | HTML + CSS（状态面板、聊天日志、通知弹窗） |
+| 部署 | Railway（后端 + 前端分离服务） |
+
+---
+
+## 架构亮点
+
+### 三文件 LLM Agent 设计
+
+每只宠物的 OpenClaw 容器由三个文件驱动：
+
+- **`SOUL.md`** — 宠物身份与个性，作为 LLM 系统提示词加载。由用户的灵魂描述句生成。
+- **`SKILL.md`** — 工具定义。将宠物能力（`visit_pet`、`send_gift`、`speak`、`rest`）映射为 LLM 工具调用，通过 `curl` 调用 PawClaw 后端执行。
+- **`HEARTBEAT.md`** — OpenClaw 心跳机制定期读取的检查清单，驱动宠物在显式 tick 之间的主动行为。
+
+### OpenClaw 容器运行时
+
+每只宠物在 Hetzner VPS 上运行独立的 `ghcr.io/openclaw/openclaw:latest` Docker 容器。后端通过 SSH 使用 `dockerode` SDK 管理容器。容器配置、SOUL.md 和技能文件通过 bind mount 挂载自宿主机 `/data/pets/{uuid}/` 目录。
+
+tick 循环工作流程如下：
+```
+PawClaw 后端 tick 触发
+  → POST http://<hetzner-host>:<pet-port>/webhook/<id>
+  → OpenClaw 执行 LLM turn（读取 SOUL.md，运行技能）
+  → OpenClaw 通过 webhook egress 将结果 POST 回 PawClaw 后端
+  → PawClaw 后端处理结果 → 向前端发送 WebSocket 事件
+```
+
+### X402 两阶段支付握手
+
+```
+宠物行动触发支付
+  → POST /api/resource（无认证头）
+  → 服务器返回 402 + 支付详情
+  → 宠物钱包签名 + 提交交易到 X Layer
+  → 服务器验证交易 → 完成请求
+```
+
+OKX 钱包技能（`okx-agentic-wallet/SKILL.md`、`okx-x402-payment/SKILL.md`）在容器创建时从 OKX onchainos-skills 仓库拉取。LLM 智能体通过内置 `exec` 工具自主决定调用 `onchainos` CLI 命令的时机。
+
+---
+
+## 项目结构
+
+```
+packages/
+├── shared/
+│   └── types/          ← 共享 TypeScript 类型、Zod schema、DB 类型
+├── backend/
+│   └── src/
+│       ├── api/        ← Fastify REST 路由处理器
+│       ├── ws/         ← WebSocket 服务器 + 事件发射器
+│       ├── runtime/    ← 宠物 tick 循环 + LLM 执行引擎
+│       ├── social/     ← 社交事件引擎（拜访、对话、情感值）
+│       ├── onchain/    ← Onchain OS 钱包 + X Layer 集成
+│       ├── payment/    ← X402 中间件
+│       └── db/         ← Drizzle schema + 数据库客户端
+└── frontend/
+    └── src/
+        ├── canvas/     ← PixiJS 场景、精灵、动画
+        ├── ws/         ← WebSocket 客户端 + 事件分发
+        └── ui/         ← DOM 状态面板、聊天日志、通知弹窗
+```
+
+---
+
+## 快速开始（本地开发）
+
+**前置要求：** Node.js 22、pnpm 9、Docker、Supabase CLI
+
+```bash
+# 1. 安装依赖
+pnpm install
+
+# 2. 启动本地 Supabase（PostgreSQL 运行于 localhost:54322）
+supabase start
+
+# 3. 复制环境变量
+cp .env.example .env
+
+# 4. 执行数据库迁移
+pnpm --filter @pawclaw/backend db:migrate
+
+# 5. 启动所有服务
+pnpm dev
+```
+
+后端启动于 `http://localhost:3000`，前端开发服务器启动于 `http://localhost:5173`。
+
+---
+
+## 核心数据模型
+
+```typescript
+Pet {
+  id, owner_id, name
+  soul_md: text          // SOUL.md 内容 — LLM 系统提示词
+  skill_md: text         // SKILL.md 内容 — 可用工具调用
+  wallet_address: string // Onchain OS 智能体钱包
+  hunger: number         // 0–100，随时间衰减
+  mood: number           // 0–100
+  affection: number      // 社交分数，每次正向事件增加
+  llm_history: jsonb     // 对话历史
+  last_tick_at: timestamp
+}
+
+SocialEvent {
+  from_pet_id, to_pet_id
+  type: 'visit' | 'gift' | 'chat'
+  payload: jsonb         // 对话内容、礼物详情、交易哈希
+}
+
+Transaction {
+  from_wallet, to_wallet, amount, token
+  tx_hash: string
+  x_layer_confirmed: boolean
+}
+```
+
+---
+
+## 部署说明
+
+- **后端**：Railway 服务 — Fastify HTTP + WebSocket 运行于单端口，自动检测 `packages/backend/Dockerfile`
+- **前端**：Railway 服务 — 静态构建，自动检测 `packages/frontend/Dockerfile`
+- **数据库**：Supabase PostgreSQL（外部托管）
+- **宠物容器**：每只宠物独立 Docker 容器，部署于 Hetzner VPS，由后端通过 SSH 管理
+
+---
+
+## 文档
+
+- [`docs/architecture.md`](docs/architecture.md) — 完整系统架构与技术决策
+- [`docs/mvp-spec.md`](docs/mvp-spec.md) — MVP 范围与演示脚本
+- [`docs/risks.md`](docs/risks.md) — 开放问题与技术阻塞项
+- [`docs/soul-skill-format.md`](docs/soul-skill-format.md) — SOUL.md / SKILL.md / HEARTBEAT.md 格式规范


### PR DESCRIPTION
## Summary

- Adds `README.md` (English, default) with project overview, core features, tech stack, architecture highlights, project structure, quick start, and deployment details
- Adds `README.zh.md` (Chinese translation) with identical content
- Language switcher links at the top of both files

## Content

Sourced entirely from `docs/architecture.md` and `docs/mvp-spec.md` — no fabricated content.

Covers:
- What PawClaw is and the hackathon context
- SOUL.md / SKILL.md / HEARTBEAT.md three-file LLM agent design
- OpenClaw Docker-per-pet runtime and tick loop integration
- X402 two-phase payment handshake
- Full tech stack table and project structure
- Local dev quick start steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)