### PR TITLE
feat(ui): logout button with confirmation dialog

### DIFF
--- a/packages/frontend/src/ui/Nameplate.ts
+++ b/packages/frontend/src/ui/Nameplate.ts
@@ -36,7 +36,51 @@ export class Nameplate {
       });
     });
 
-    this.el.append(this.statusDot, this.nameEl, this.walletEl);
+    const logoutBtn = document.createElement('button');
+    logoutBtn.className = 'logout-btn';
+    logoutBtn.textContent = 'Logout';
+    logoutBtn.addEventListener('click', () => this.showLogoutDialog());
+
+    this.el.append(this.statusDot, this.nameEl, this.walletEl, logoutBtn);
+  }
+
+  private showLogoutDialog(): void {
+    const backdrop = document.createElement('div');
+    backdrop.id = 'logout-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.id = 'logout-dialog';
+    dialog.classList.add('ui-panel');
+
+    const msg = document.createElement('p');
+    msg.className = 'logout-message';
+    msg.textContent = 'Are you sure you want to logout?';
+
+    const btnRow = document.createElement('div');
+    btnRow.className = 'logout-btn-row';
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'logout-confirm-btn';
+    confirmBtn.textContent = 'Confirm';
+    confirmBtn.addEventListener('click', () => {
+      localStorage.removeItem('token');
+      localStorage.removeItem('pet_id');
+      window.location.href = '/create.html';
+    });
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'logout-cancel-btn';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => backdrop.remove());
+
+    backdrop.addEventListener('click', (e) => {
+      if (e.target === backdrop) backdrop.remove();
+    });
+
+    btnRow.append(confirmBtn, cancelBtn);
+    dialog.append(msg, btnRow);
+    backdrop.append(dialog);
+    document.body.append(backdrop);
   }
 
   setName(name: string): void {

--- a/packages/frontend/src/ui/styles.css
+++ b/packages/frontend/src/ui/styles.css
@@ -103,6 +103,92 @@
   font-family: var(--ui-font-body);
 }
 
+/* ── Logout button ────────────────────────────────────────────────── */
+.logout-btn {
+  background: none;
+  border: 1px solid var(--ui-brown-light);
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 9px;
+  font-family: var(--ui-font-pixel);
+  color: var(--ui-text-muted);
+  cursor: pointer;
+  margin-left: auto;
+  flex-shrink: 0;
+  pointer-events: auto;
+}
+
+.logout-btn:hover {
+  border-color: var(--ui-brown);
+  color: var(--ui-brown);
+  background: rgba(139, 111, 71, 0.08);
+}
+
+/* ── Logout confirmation dialog ───────────────────────────────────── */
+#logout-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(74, 55, 40, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+#logout-dialog {
+  width: min(320px, 90%);
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.logout-message {
+  margin: 0;
+  font-family: var(--ui-font-body);
+  font-size: 13px;
+  color: var(--ui-text);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.logout-btn-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.logout-confirm-btn {
+  background: #b84040;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  padding: 6px 18px;
+  font-size: 12px;
+  font-family: var(--ui-font-body);
+  cursor: pointer;
+}
+
+.logout-confirm-btn:hover {
+  background: #9e3535;
+}
+
+.logout-cancel-btn {
+  background: var(--ui-brown-light);
+  color: var(--ui-text);
+  border: none;
+  border-radius: 5px;
+  padding: 6px 18px;
+  font-size: 12px;
+  font-family: var(--ui-font-body);
+  cursor: pointer;
+}
+
+.logout-cancel-btn:hover {
+  background: var(--ui-brown);
+  color: var(--ui-cream);
+}
+
 /* ── Chat log ─────────────────────────────────────────────────────── */
 #chat-log {
   position: absolute;


### PR DESCRIPTION
## Summary

- Adds a small **Logout** button at the right end of the pet nameplate row (pixel-style, unobtrusive)
- Clicking shows a centered confirmation overlay with semi-transparent backdrop (plain DOM, no external libs)
- Confirming clears `localStorage` (`token` + `pet_id`) and redirects to `/create.html`
- Cancelling or clicking the backdrop dismisses the dialog with no side effects

## Test plan

- [x] Logout button appears at the right end of the nameplate
- [x] Clicking Logout opens the confirmation dialog
- [x] Cancel / backdrop click dismisses dialog without logging out
- [x] Confirm clears `localStorage.token` and `localStorage.pet_id`, then redirects to `/create.html`
- [x] Button and dialog style matches existing `ui-panel` pixel aesthetic

## E2E Results

| Chain | Description | Result |
|-------|-------------|--------|
| Nameplate-A | Logout button present in nameplate | ✅ PASS |
| Nameplate-B | Confirmation dialog appears on click | ✅ PASS |
| Nameplate-C | Cancel dismisses dialog, stays on page | ✅ PASS |
| Nameplate-D | Confirm logs out and navigates to `/create.html` | ✅ PASS |
| 8 | HUD Bar + SVG Icons unaffected | ✅ PASS |
| 11 | WalletPanel modal unaffected | ✅ PASS |
| 12 | Friends Panel unaffected | ✅ PASS |

closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)