### PR TITLE
fix(ws): JWT_SECRET fallback for local dev + port range 19→20k

### DIFF
--- a/packages/backend/src/ws/wsRoute.ts
+++ b/packages/backend/src/ws/wsRoute.ts
@@ -1,3 +1,4 @@
+import { createSecretKey } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { WsQuerySchema } from '@pawclaw/shared';
@@ -5,6 +6,25 @@ import { registerOwner, unregisterOwner } from './wsRegistry.js';
 
 const supabaseUrl = process.env.SUPABASE_URL!;
 const JWKS = createRemoteJWKSet(new URL(`${supabaseUrl}/auth/v1/.well-known/jwks.json`));
+
+// Local Supabase uses HS256 (symmetric) — JWKS returns empty keys.
+// Fall back to JWT_SECRET for local dev (mirrors authHook.ts).
+const jwtSecret = process.env.JWT_SECRET
+  ? createSecretKey(Buffer.from(process.env.JWT_SECRET))
+  : null;
+
+async function verifyToken(token: string): Promise<string> {
+  try {
+    const { payload } = await jwtVerify(token, JWKS);
+    if (!payload.sub) throw new Error('missing sub');
+    return payload.sub;
+  } catch {
+    if (!jwtSecret) throw new Error('JWKS failed and no JWT_SECRET set');
+    const { payload } = await jwtVerify(token, jwtSecret);
+    if (!payload.sub) throw new Error('missing sub');
+    return payload.sub;
+  }
+}
 
 export async function registerWsRoute(fastify: FastifyInstance): Promise<void> {
   fastify.get('/ws', { websocket: true }, (socket, req) => {
@@ -14,11 +34,8 @@ export async function registerWsRoute(fastify: FastifyInstance): Promise<void> {
       return;
     }
 
-    jwtVerify(query.data.token, JWKS)
-      .then(({ payload }) => {
-        if (!payload.sub) throw new Error('missing sub');
-        const ownerId = payload.sub;
-
+    verifyToken(query.data.token)
+      .then((ownerId) => {
         registerOwner(ownerId, socket);
         fastify.log.info({ ownerId }, 'ws client connected');
 


### PR DESCRIPTION
## Summary

- **`wsRoute.ts`**: Add `JWT_SECRET` fallback matching `authHook.ts` — local Supabase uses HS256 so JWKS returns `{"keys":[]}`, causing all WS connections to fail with `4001` in local dev
- **`container.ts`**: Change pet container port range from `19000–19999` → `20000–20999` to avoid collision with OrbStack which occupies `19000–19008` on the host

## Test plan

- [ ] Restart local backend, open `ws://localhost:3001/ws?token=<local-jwt>` — should connect without `4001`
- [ ] Create a new pet — container should bind a `200xx` port instead of `190xx`
- [ ] `DELETE FROM port_allocations;` to clear stale 19xxx records before testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)