### PR TITLE
fix(ui): apply wallet pending state to Nameplate

### DIFF
--- a/packages/frontend/src/ui/Nameplate.ts
+++ b/packages/frontend/src/ui/Nameplate.ts
@@ -1,3 +1,8 @@
+/** Returns true only for a real 42-char EVM address (no placeholders). */
+function isRealAddress(addr: string | null | undefined): addr is string {
+  return typeof addr === 'string' && addr.length === 42 && addr.startsWith('0x') && !addr.includes('...');
+}
+
 /** Pet nameplate — name, status indicator, truncated wallet address. */
 export class Nameplate {
   readonly el: HTMLDivElement;
@@ -7,7 +12,6 @@ export class Nameplate {
 
   constructor(
     name = 'My Pet',
-    wallet = '0x0000...0000',
     status: 'online' | 'starting' | 'offline' = 'online',
   ) {
     this.el = document.createElement('div');
@@ -23,11 +27,10 @@ export class Nameplate {
     this.nameEl.textContent = name;
 
     this.walletEl = document.createElement('span');
-    this.walletEl.className = 'pet-wallet';
-    this.walletEl.title = 'Click to copy';
-    this.walletEl.style.cursor = 'pointer';
-    this.walletEl.textContent = wallet;
+    this.walletEl.className = 'pet-wallet wallet-address-pending';
+    this.walletEl.textContent = 'Creating wallet\u2026';
     this.walletEl.addEventListener('click', () => {
+      if (this.walletEl.classList.contains('wallet-address-pending')) return;
       const full = this.walletEl.dataset.full ?? this.walletEl.textContent ?? '';
       navigator.clipboard.writeText(full).then(() => {
         const prev = this.walletEl.textContent;
@@ -87,11 +90,20 @@ export class Nameplate {
     this.nameEl.textContent = name;
   }
 
-  setWallet(address: string): void {
-    this.walletEl.dataset.full = address;
-    this.walletEl.textContent = address.length > 14
-      ? `${address.slice(0, 6)}...${address.slice(-4)}`
-      : address;
+  setWallet(address: string | null | undefined): void {
+    if (isRealAddress(address)) {
+      this.walletEl.dataset.full = address;
+      this.walletEl.textContent = `${address.slice(0, 6)}...${address.slice(-4)}`;
+      this.walletEl.classList.remove('wallet-address-pending');
+      this.walletEl.title = 'Click to copy';
+      this.walletEl.style.cursor = 'pointer';
+    } else {
+      delete this.walletEl.dataset.full;
+      this.walletEl.textContent = 'Creating wallet\u2026';
+      this.walletEl.classList.add('wallet-address-pending');
+      this.walletEl.title = '';
+      this.walletEl.style.cursor = 'default';
+    }
   }
 
   setStatus(status: 'online' | 'starting' | 'offline'): void {

--- a/packages/frontend/src/ui/index.ts
+++ b/packages/frontend/src/ui/index.ts
@@ -30,7 +30,7 @@ export function initUI(mount: HTMLElement, petId?: string, token?: string): { ch
   const overlay = document.createElement('div');
   overlay.id = 'ui-overlay';
 
-  const nameplate = new Nameplate('My Pet', '0x1234...5678', 'online');
+  const nameplate = new Nameplate('My Pet', 'online');
   const chatLog = new ChatLog();
   const toasts = new Toasts();
   const hudBar = new HudBar(petId, token);
@@ -45,7 +45,7 @@ export function initUI(mount: HTMLElement, petId?: string, token?: string): { ch
       .then((r) => r.ok ? r.json() as Promise<{ name?: string; wallet_address?: string | null }> : null)
       .then((data) => {
         if (data?.name) nameplate.setName(data.name);
-        if (data?.wallet_address) nameplate.setWallet(data.wallet_address);
+        nameplate.setWallet(data?.wallet_address);
         hudBar.walletPanel.setAddress(data?.wallet_address);
       })
       .catch(() => {});
@@ -56,6 +56,7 @@ export function initUI(mount: HTMLElement, petId?: string, token?: string): { ch
     hudBar.updateStats(e.data.hunger, e.data.mood, e.data.affection);
     if (e.data.wallet_address !== undefined) {
       hudBar.walletPanel.setAddress(e.data.wallet_address);
+      nameplate.setWallet(e.data.wallet_address);
     }
   });
 


### PR DESCRIPTION
## Summary

- Constructor now starts in pending state: shows "Creating wallet…" (greyed, italic, non-copyable via `.wallet-address-pending` CSS class already added in #160)
- `setWallet(string | null | undefined)` transitions to real truncated address when a valid 42-char EVM address arrives; reverts to pending otherwise
- Click handler bails early when pending class is present
- `index.ts`: placeholder arg removed from constructor; initial REST fetch calls `nameplate.setWallet()` unconditionally; WS `pet.state` handler now also calls `nameplate.setWallet()` alongside `walletPanel.setAddress()`

## Test plan

- [ ] On page load with no wallet yet: nameplate shows "Creating wallet…" (greyed, italic, not copyable)
- [ ] When `pet.state` WS event arrives with a real `wallet_address`, nameplate updates live to truncated address
- [ ] Clicking the address copies the full address to clipboard
- [ ] Clicking while pending does nothing

closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)