### PR TITLE
feat(auth): auto-refresh Supabase session + graceful 401 handling

### DIFF
--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -1,0 +1,20 @@
+import { clearAuth } from './auth';
+
+const BACKEND_URL = (import.meta.env.VITE_BACKEND_URL as string | undefined) ?? 'http://localhost:3001';
+
+export { BACKEND_URL };
+
+/**
+ * Fetch wrapper for authenticated API calls.
+ * On 401: clears stored auth and redirects to /create.html?reason=expired.
+ */
+export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  const res = await fetch(`${BACKEND_URL}${path}`, init);
+  if (res.status === 401) {
+    clearAuth();
+    window.location.replace('/create.html?reason=expired');
+    // Pending promise — page is redirecting
+    return new Promise(() => {});
+  }
+  return res;
+}

--- a/packages/frontend/src/auth.ts
+++ b/packages/frontend/src/auth.ts
@@ -1,8 +1,13 @@
+import { createClient } from '@supabase/supabase-js';
+
 const AUTH_KEY = 'pawclaw_auth';
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 interface AuthState {
   token: string;
   pet_id: string;
+  refresh_token?: string;
 }
 
 export function getAuth(): AuthState | null {
@@ -11,16 +16,41 @@ export function getAuth(): AuthState | null {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<AuthState>;
     if (!parsed.token || !parsed.pet_id) return null;
-    return { token: parsed.token, pet_id: parsed.pet_id };
+    return { token: parsed.token, pet_id: parsed.pet_id, refresh_token: parsed.refresh_token };
   } catch {
     return null;
   }
 }
 
-export function setAuth(token: string, pet_id: string): void {
-  localStorage.setItem(AUTH_KEY, JSON.stringify({ token, pet_id }));
+export function setAuth(token: string, pet_id: string, refresh_token?: string): void {
+  localStorage.setItem(AUTH_KEY, JSON.stringify({ token, pet_id, refresh_token }));
 }
 
 export function clearAuth(): void {
   localStorage.removeItem(AUTH_KEY);
+}
+
+/**
+ * Attempts to refresh the Supabase session using the stored refresh_token.
+ * Updates localStorage with fresh tokens on success.
+ * Returns the fresh access token, or null if refresh is not possible.
+ */
+export async function refreshSession(): Promise<string | null> {
+  const auth = getAuth();
+  if (!auth) return null;
+  if (!auth.refresh_token) return auth.token;
+
+  try {
+    const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    const { data, error } = await supabase.auth.setSession({
+      access_token: auth.token,
+      refresh_token: auth.refresh_token,
+    });
+    if (error || !data.session) return null;
+
+    setAuth(data.session.access_token, auth.pet_id, data.session.refresh_token);
+    return data.session.access_token;
+  } catch {
+    return null;
+  }
 }

--- a/packages/frontend/src/create/main.ts
+++ b/packages/frontend/src/create/main.ts
@@ -48,6 +48,13 @@ colorCustomInput.addEventListener('input', () => {
 
 let isSignUp = false;
 let accessToken = '';
+let refreshToken = '';
+
+// --- Session expired message ---
+const expiredReason = new URLSearchParams(location.search).get('reason');
+if (expiredReason === 'expired') {
+  errorMsg.textContent = 'Session expired, please sign in again.';
+}
 
 // --- Auth toggle ---
 toggleBtn.addEventListener('click', () => {
@@ -82,6 +89,7 @@ authBtn.addEventListener('click', async () => {
     }
 
     accessToken = data.session?.access_token ?? '';
+    refreshToken = data.session?.refresh_token ?? '';
     if (!accessToken) {
       errorMsg.textContent = 'Auth succeeded but no session token returned.';
       return;
@@ -94,7 +102,7 @@ authBtn.addEventListener('click', async () => {
     if (petsRes.ok) {
       const pets = await petsRes.json() as Array<{ id: string }>;
       if (pets.length > 0) {
-        setAuth(accessToken, pets[0].id);
+        setAuth(accessToken, pets[0].id, refreshToken);
         window.location.replace('/');
         return;
       }
@@ -142,7 +150,7 @@ createBtn.addEventListener('click', async () => {
     }
 
     // Persist auth and redirect to the canvas
-    setAuth(accessToken, data.id ?? '');
+    setAuth(accessToken, data.id ?? '', refreshToken);
     window.location.replace('/');
   } catch (err) {
     errorMsgPet.textContent = err instanceof Error ? err.message : 'Unknown error';

--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -5,7 +5,8 @@ import { MockEvents } from './canvas/MockEvents';
 import { eventBus } from './ws/eventBus';
 import { WsClient, buildWsUrl } from './ws/WsClient';
 import { initUI } from './ui';
-import { getAuth } from './auth';
+import { getAuth, refreshSession } from './auth';
+import { apiFetch, BACKEND_URL } from './api';
 
 // Crisp pixel-art rendering — nearest-neighbour, no bilinear blur.
 TextureStyle.defaultOptions.scaleMode = 'nearest';
@@ -28,8 +29,18 @@ async function main(): Promise<void> {
   const params = new URLSearchParams(location.search);
   // Prefer localStorage auth; fall back to URL params for backwards compat
   const stored = getAuth();
-  const token = stored?.token ?? params.get('token') ?? import.meta.env.VITE_WS_TOKEN as string | undefined;
-  const petId = stored?.pet_id ?? params.get('pet_id') ?? undefined;
+  let token: string | undefined;
+  let petId: string | undefined;
+
+  if (stored) {
+    // Attempt to refresh the session — SDK auto-refreshes if access token is expired
+    const freshToken = await refreshSession();
+    token = freshToken ?? stored.token;
+    petId = stored.pet_id;
+  } else {
+    token = params.get('token') ?? import.meta.env.VITE_WS_TOKEN as string | undefined;
+    petId = params.get('pet_id') ?? undefined;
+  }
 
   if (!token || !petId) {
     window.location.replace('/create.html');
@@ -94,8 +105,7 @@ async function main(): Promise<void> {
   eventBus.on('error',          (e) => room.showDialogue(`Error: ${e.data.message}`));
 
   // Fetch initial pet state and apply tint + stats
-  const backendUrl = (import.meta.env.VITE_BACKEND_URL as string | undefined) ?? 'http://localhost:3001';
-  fetch(`${backendUrl}/api/pets/${petId}`, {
+  apiFetch(`/api/pets/${petId}`, {
     headers: { Authorization: `Bearer ${token}` },
   })
     .then((res) => res.ok ? res.json() as Promise<{ tint_color?: string; hunger?: number; mood?: number; affection?: number }> : Promise.resolve({} as { tint_color?: string; hunger?: number; mood?: number; affection?: number }))
@@ -104,7 +114,7 @@ async function main(): Promise<void> {
         room.applyPetTint(data.tint_color);
       }
       if (data.hunger != null && data.mood != null && data.affection != null) {
-        room.updateStats({ pet_id: petId, hunger: data.hunger, mood: data.mood, affection: data.affection });
+        room.updateStats({ pet_id: petId!, hunger: data.hunger, mood: data.mood, affection: data.affection });
       }
     })
     .catch(() => { /* non-critical */ });

--- a/packages/frontend/src/ui/ChatLog.ts
+++ b/packages/frontend/src/ui/ChatLog.ts
@@ -1,9 +1,9 @@
 import { getAuth } from '../auth';
+import { apiFetch } from '../api';
 import { renderMarkdown } from './markdown';
 import { SentenceDetector } from '../ws/SentenceDetector';
 
 const MAX_ENTRIES = 50;
-const BACKEND_URL = (import.meta.env.VITE_BACKEND_URL as string | undefined) ?? 'http://localhost:3001';
 
 // petId → display name, populated lazily from GET /api/pets/:id
 const petNames = new Map<string, string>();
@@ -12,7 +12,7 @@ export async function resolvePetName(petId: string, token: string | null): Promi
   if (petNames.has(petId)) return petNames.get(petId)!;
   if (!token) return petId;
   try {
-    const res = await fetch(`${BACKEND_URL}/api/pets/${petId}`, {
+    const res = await apiFetch(`/api/pets/${petId}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (res.ok) {
@@ -101,7 +101,7 @@ export class ChatLog {
       this.dialogueHandlers?.startThinking();
 
       try {
-        const res = await fetch(`${BACKEND_URL}/api/pets/${petId}/chat`, {
+        const res = await apiFetch(`/api/pets/${petId}/chat`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/frontend/src/ui/DiaryPanel.ts
+++ b/packages/frontend/src/ui/DiaryPanel.ts
@@ -1,7 +1,6 @@
 import { Icons } from './icons';
 import { getAuth } from '../auth';
-
-const BACKEND_URL = (import.meta.env.VITE_BACKEND_URL as string | undefined) ?? 'http://localhost:3001';
+import { apiFetch } from '../api';
 
 /** Centered modal overlay showing the pet's diary from GET /api/pets/:id/diary. */
 export class DiaryPanel {
@@ -61,7 +60,7 @@ export class DiaryPanel {
     const headers: Record<string, string> = {};
     if (token) headers['Authorization'] = `Bearer ${token}`;
 
-    fetch(`${BACKEND_URL}/api/pets/${petId}/diary`, { headers })
+    apiFetch(`/api/pets/${petId}/diary`, { headers })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json() as Promise<{ diary: string | null; created_at?: string }>;

--- a/packages/frontend/src/ui/WalletPanel.ts
+++ b/packages/frontend/src/ui/WalletPanel.ts
@@ -1,6 +1,5 @@
 import { Icons } from './icons';
-
-const BACKEND_URL = (import.meta.env.VITE_BACKEND_URL as string | undefined) ?? 'http://localhost:3001';
+import { apiFetch } from '../api';
 
 /** Returns true if the address is a real on-chain address (non-empty, non-placeholder). */
 function isRealAddress(addr: string | null | undefined): addr is string {
@@ -244,7 +243,7 @@ export class WalletPanel {
 
   private _fetchData(): void {
     if (!this.petId || !this.token) return;
-    fetch(`${BACKEND_URL}/api/pets/${this.petId}`, {
+    apiFetch(`/api/pets/${this.petId}`, {
       headers: { Authorization: `Bearer ${this.token}` },
     })
       .then((res) => {


### PR DESCRIPTION
## Summary

- **Part A — Auto-refresh**: `auth.ts` now stores `refresh_token` alongside the access token. On app init, `main.ts` calls `refreshSession()` which uses `supabase.auth.setSession()` to let the SDK rotate the access token transparently — users never see a 401 from normal 1-hour expiry.
- **Part B — Graceful fallback**: New `src/api.ts` exports `apiFetch()` — a thin fetch wrapper that on 401 calls `clearAuth()` and redirects to `/create.html?reason=expired`. All authenticated `fetch()` calls in `ChatLog.ts`, `DiaryPanel.ts`, `WalletPanel.ts`, and `main.ts` are replaced with `apiFetch()`.
- `create/main.ts` detects `?reason=expired` on load and shows "Session expired, please sign in again."

## Test plan

- [ ] Sign in, verify `pawclaw_auth` in localStorage now includes `refresh_token`
- [ ] Let access token expire (or manually shorten JWT TTL in Supabase dashboard); reload — app should work without 401
- [ ] Manually clear `refresh_token` from localStorage and set an expired `token`; reload — should redirect to `/create.html?reason=expired` with the session-expired message
- [ ] Verify all API-backed UI panels (Chat, Diary, Wallet) still load correctly after a fresh sign-in

closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)