### PR TITLE
fix(frontend): use warm cream panel style for stat tooltip

### DIFF
--- a/packages/frontend/scripts/tooltip-fixture.ts
+++ b/packages/frontend/scripts/tooltip-fixture.ts
@@ -12,7 +12,7 @@ const __dir = dirname(fileURLToPath(import.meta.url));
 const cssPath = resolve(__dir, '../src/ui/styles.css');
 const css = readFileSync(cssPath, 'utf8')
   // strip @import (Google Fonts) so it renders offline
-  .replace(/@import[^;]+;/g, '');
+  .replace(/^@import .+$/gm, '');
 
 const output = process.env.SCREENSHOT_OUTPUT ?? '/tmp/tooltip-test.png';
 
@@ -22,7 +22,7 @@ const html = `<!DOCTYPE html>
 <meta charset="UTF-8"/>
 <style>
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body { background: #3a7a3a; width: 900px; height: 400px; position: relative; overflow: hidden;
+body { background: #2a2a2a; width: 900px; height: 400px; position: relative; overflow: hidden;
        font-family: Inter, system-ui, sans-serif; }
 ${css}
 </style>

--- a/packages/frontend/src/ui/styles.css
+++ b/packages/frontend/src/ui/styles.css
@@ -485,15 +485,16 @@
   margin-bottom: 6px;
   left: 0;
   z-index: 100;
-  background: rgba(30, 20, 10, 0.95);
-  border: 1px solid var(--ui-brown-light);
+  background: var(--ui-panel-bg);
+  border: 1px solid var(--ui-panel-border);
   border-radius: 6px;
   padding: 8px 10px;
   min-width: 220px;
   max-width: 280px;
   font-size: 11px;
-  color: var(--ui-text-muted);
+  color: var(--ui-text);
   line-height: 1.5;
+  box-shadow: 0 2px 8px var(--ui-shadow);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

- Replaces near-black `rgba(30,20,10,0.95)` tooltip background with `var(--ui-panel-bg)` (warm cream) to match the rest of the UI panels
- Uses `var(--ui-panel-border)` for the border and `var(--ui-text)` for text color
- Adds `box-shadow` for depth consistency with other panels

Note: the other two tasks in #185 (TS2554 type fix + icon alignment) were already merged in #181.

addresses tooltip color task from #185

## Test plan

- [ ] Hover the `?` button in the HUD stat bar — tooltip appears with cream background, dark brown text, matching panel style
- [ ] Verify on both light and dark game backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)